### PR TITLE
No std

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # rustls-wolfcrypt-provider
 
-Code that lets you use wolfCrypt as a crypto provider for Rustls.
+Code that lets you use `wolfCrypt` as a crypto provider for `Rustls`, with
+`no_std` support by default. The `std` library is only used in tests and the
+`build.rs` file for binding generation; the core crypto provider itself does
+not depend on `std`.
 
 ## Status
 

--- a/rustls-wolfcrypt-provider/Cargo.toml
+++ b/rustls-wolfcrypt-provider/Cargo.toml
@@ -41,5 +41,5 @@ tokio = { version = "1.41", features = ["macros", "rt", "net", "io-util", "io-st
 webpki-roots = "0.26"
 
 [features]
-default = ["std"]
-std = ["hpke-rs/std", "hpke-rs-crypto/std", "pkcs8/std", "rustls/std"]
+default = []
+std = ["hpke-rs/std", "hpke-rs-crypto/std", "pkcs8/std", "rustls/std", "wolfcrypt-rs/std"]

--- a/rustls-wolfcrypt-provider/src/aead/aes128gcm.rs
+++ b/rustls-wolfcrypt-provider/src/aead/aes128gcm.rs
@@ -1,6 +1,8 @@
 use crate::error::check_if_zero;
 use crate::types::types::*;
 use alloc::boxed::Box;
+use alloc::vec;
+use core::mem;
 use foreign_types::ForeignType;
 use rustls::crypto::cipher::{
     make_tls12_aad, make_tls13_aad, AeadKey, InboundOpaqueMessage, InboundPlainMessage, Iv,
@@ -9,8 +11,9 @@ use rustls::crypto::cipher::{
     UnsupportedOperationError,
 };
 use rustls::{ConnectionTrafficSecrets, ContentType, ProtocolVersion};
-use std::mem;
-use std::vec;
+
+use alloc::vec::Vec;
+use core::ptr;
 use wolfcrypt_rs::*;
 
 const GCM_NONCE_LENGTH: usize = 12;
@@ -113,7 +116,7 @@ impl MessageEncrypter for WCTls12Encrypter {
         let mut ret;
 
         // Initialize Aes structure.
-        ret = unsafe { wc_AesInit(aes_object.as_ptr(), std::ptr::null_mut(), INVALID_DEVID) };
+        ret = unsafe { wc_AesInit(aes_object.as_ptr(), ptr::null_mut(), INVALID_DEVID) };
         check_if_zero(ret).unwrap();
 
         // This function is used to set the key for AES GCM (Galois/Counter Mode).
@@ -189,7 +192,7 @@ impl MessageDecrypter for WCTls12Decrypter {
         let aes_object = unsafe { AesObject::from_ptr(&mut aes_c_type) };
         let mut ret;
 
-        ret = unsafe { wc_AesInit(aes_object.as_ptr(), std::ptr::null_mut(), INVALID_DEVID) };
+        ret = unsafe { wc_AesInit(aes_object.as_ptr(), ptr::null_mut(), INVALID_DEVID) };
         check_if_zero(ret).unwrap();
 
         ret = unsafe {
@@ -289,7 +292,7 @@ impl MessageEncrypter for WCTls13Cipher {
         let mut ret;
 
         // Initialize Aes structure.
-        ret = unsafe { wc_AesInit(aes_object.as_ptr(), std::ptr::null_mut(), INVALID_DEVID) };
+        ret = unsafe { wc_AesInit(aes_object.as_ptr(), ptr::null_mut(), INVALID_DEVID) };
         check_if_zero(ret).unwrap();
 
         // This function is used to set the key for AES GCM (Galois/Counter Mode).
@@ -359,7 +362,7 @@ impl MessageDecrypter for WCTls13Cipher {
         let aes_object = unsafe { AesObject::from_ptr(&mut aes_c_type) };
         let mut ret;
 
-        ret = unsafe { wc_AesInit(aes_object.as_ptr(), std::ptr::null_mut(), INVALID_DEVID) };
+        ret = unsafe { wc_AesInit(aes_object.as_ptr(), ptr::null_mut(), INVALID_DEVID) };
         check_if_zero(ret).unwrap();
 
         ret = unsafe {
@@ -441,7 +444,7 @@ mod tests {
             let mut ret;
 
             // Initialize Aes structure.
-            ret = wc_AesInit(aes_object.as_ptr(), std::ptr::null_mut(), INVALID_DEVID);
+            ret = wc_AesInit(aes_object.as_ptr(), ptr::null_mut(), INVALID_DEVID);
             check_if_zero(ret).unwrap();
 
             // This function is used to set the key for AES GCM (Galois/Counter Mode).

--- a/rustls-wolfcrypt-provider/src/aead/aes256gcm.rs
+++ b/rustls-wolfcrypt-provider/src/aead/aes256gcm.rs
@@ -1,6 +1,8 @@
 use crate::error::check_if_zero;
 use crate::types::types::*;
 use alloc::boxed::Box;
+use alloc::vec;
+use core::mem;
 use foreign_types::ForeignType;
 use rustls::crypto::cipher::{
     make_tls12_aad, make_tls13_aad, AeadKey, InboundOpaqueMessage, InboundPlainMessage, Iv,
@@ -9,8 +11,9 @@ use rustls::crypto::cipher::{
     UnsupportedOperationError,
 };
 use rustls::{ConnectionTrafficSecrets, ContentType, ProtocolVersion};
-use std::mem;
-use std::vec;
+
+use alloc::vec::Vec;
+use core::ptr;
 use wolfcrypt_rs::*;
 
 const GCM_NONCE_LENGTH: usize = 12;
@@ -113,7 +116,7 @@ impl MessageEncrypter for WCTls12Encrypter {
         let mut ret;
 
         // Initialize Aes structure.
-        ret = unsafe { wc_AesInit(aes_object.as_ptr(), std::ptr::null_mut(), INVALID_DEVID) };
+        ret = unsafe { wc_AesInit(aes_object.as_ptr(), ptr::null_mut(), INVALID_DEVID) };
         check_if_zero(ret).unwrap();
 
         // This function is used to set the key for AES GCM (Galois/Counter Mode).
@@ -189,7 +192,7 @@ impl MessageDecrypter for WCTls12Decrypter {
         let aes_object = unsafe { AesObject::from_ptr(&mut aes_c_type) };
         let mut ret;
 
-        ret = unsafe { wc_AesInit(aes_object.as_ptr(), std::ptr::null_mut(), INVALID_DEVID) };
+        ret = unsafe { wc_AesInit(aes_object.as_ptr(), ptr::null_mut(), INVALID_DEVID) };
         check_if_zero(ret).unwrap();
 
         ret = unsafe {
@@ -289,7 +292,7 @@ impl MessageEncrypter for WCTls13Cipher {
         let mut ret;
 
         // Initialize Aes structure.
-        ret = unsafe { wc_AesInit(aes_object.as_ptr(), std::ptr::null_mut(), INVALID_DEVID) };
+        ret = unsafe { wc_AesInit(aes_object.as_ptr(), ptr::null_mut(), INVALID_DEVID) };
         check_if_zero(ret).unwrap();
 
         // This function is used to set the key for AES GCM (Galois/Counter Mode).
@@ -359,7 +362,7 @@ impl MessageDecrypter for WCTls13Cipher {
         let aes_object = unsafe { AesObject::from_ptr(&mut aes_c_type) };
         let mut ret;
 
-        ret = unsafe { wc_AesInit(aes_object.as_ptr(), std::ptr::null_mut(), INVALID_DEVID) };
+        ret = unsafe { wc_AesInit(aes_object.as_ptr(), ptr::null_mut(), INVALID_DEVID) };
         check_if_zero(ret).unwrap();
 
         ret = unsafe {
@@ -446,7 +449,7 @@ mod tests {
             let mut ret;
 
             // Initialize Aes structure.
-            ret = wc_AesInit(aes_object.as_ptr(), std::ptr::null_mut(), INVALID_DEVID);
+            ret = wc_AesInit(aes_object.as_ptr(), ptr::null_mut(), INVALID_DEVID);
             check_if_zero(ret).unwrap();
 
             // This function is used to set the key for AES GCM (Galois/Counter Mode).

--- a/rustls-wolfcrypt-provider/src/aead/chacha20.rs
+++ b/rustls-wolfcrypt-provider/src/aead/chacha20.rs
@@ -1,5 +1,8 @@
 use alloc::boxed::Box;
+use alloc::vec;
+use alloc::vec::Vec;
 use chacha20poly1305::KeySizeUser;
+use core::mem;
 use rustls::crypto::cipher::{
     make_tls12_aad, make_tls13_aad, AeadKey, InboundOpaqueMessage, InboundPlainMessage, Iv,
     KeyBlockShape, MessageDecrypter, MessageEncrypter, Nonce, OutboundOpaqueMessage,
@@ -7,8 +10,6 @@ use rustls::crypto::cipher::{
     UnsupportedOperationError, NONCE_LEN,
 };
 use rustls::{ConnectionTrafficSecrets, ContentType, ProtocolVersion};
-use std::mem;
-use std::vec;
 use wolfcrypt_rs::*;
 
 use crate::error::check_if_zero;
@@ -312,10 +313,8 @@ impl MessageDecrypter for WCTls13Cipher {
 
 #[cfg(test)]
 mod tests {
-    use std::mem;
-    use wolfcrypt_rs::*;
 
-    use crate::error::check_if_zero;
+    use super::*;
 
     #[test]
     fn test_chacha() {

--- a/rustls-wolfcrypt-provider/src/hash/sha256.rs
+++ b/rustls-wolfcrypt-provider/src/hash/sha256.rs
@@ -1,7 +1,8 @@
 use crate::error::check_if_zero;
 use alloc::boxed::Box;
+use core::mem;
 use rustls::crypto::hash;
-use std::mem;
+
 use wolfcrypt_rs::*;
 
 pub struct WCSha256;

--- a/rustls-wolfcrypt-provider/src/hash/sha384.rs
+++ b/rustls-wolfcrypt-provider/src/hash/sha384.rs
@@ -1,6 +1,6 @@
 use alloc::boxed::Box;
+use core::mem;
 use rustls::crypto::hash;
-use std::mem;
 use wolfcrypt_rs::*;
 
 use crate::error::check_if_zero;

--- a/rustls-wolfcrypt-provider/src/hmac/sha256hmac.rs
+++ b/rustls-wolfcrypt-provider/src/hmac/sha256hmac.rs
@@ -1,9 +1,10 @@
 use crate::{error::check_if_zero, types::types::*};
 use alloc::boxed::Box;
+use alloc::vec::Vec;
 use core::mem;
 use foreign_types::ForeignType;
 use rustls::crypto;
-use std::vec::Vec;
+
 use wolfcrypt_rs::*;
 
 pub struct WCSha256Hmac;

--- a/rustls-wolfcrypt-provider/src/hmac/sha384hmac.rs
+++ b/rustls-wolfcrypt-provider/src/hmac/sha384hmac.rs
@@ -1,9 +1,9 @@
 use crate::{error::check_if_zero, types::types::*};
 use alloc::boxed::Box;
+use alloc::vec::Vec;
 use core::mem;
 use foreign_types::ForeignType;
 use rustls::crypto;
-use std::vec::Vec;
 use wolfcrypt_rs::*;
 
 pub struct WCSha384Hmac;

--- a/rustls-wolfcrypt-provider/src/kx/sec256r1.rs
+++ b/rustls-wolfcrypt-provider/src/kx/sec256r1.rs
@@ -1,6 +1,9 @@
 use crate::{error::check_if_zero, types::types::*};
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::mem;
+use core::ptr;
 use foreign_types::ForeignType;
-use std::mem;
 use wolfcrypt_rs::*;
 
 pub struct KeyExchangeSecP256r1 {
@@ -103,7 +106,7 @@ impl KeyExchangeSecP256r1 {
             wc_ecc_import_private_key_ex(
                 self.priv_key_bytes.as_ptr(),
                 self.priv_key_bytes.len() as word32,
-                std::ptr::null_mut(),
+                ptr::null_mut(),
                 0,
                 priv_key_object.as_ptr(),
                 ecc_curve_id_ECC_SECP256R1,
@@ -120,7 +123,7 @@ impl KeyExchangeSecP256r1 {
                 pub_key_object.as_ptr(),
                 peer_pub_key[1..33].as_ptr(),
                 peer_pub_key[33..].as_ptr(),
-                std::ptr::null_mut(),
+                ptr::null_mut(),
                 ecc_curve_id_ECC_SECP256R1,
             )
         };

--- a/rustls-wolfcrypt-provider/src/kx/sec384r1.rs
+++ b/rustls-wolfcrypt-provider/src/kx/sec384r1.rs
@@ -1,7 +1,10 @@
 use crate::error::*;
 use crate::types::types::*;
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::mem;
+use core::ptr;
 use foreign_types::ForeignType;
-use std::mem;
 use wolfcrypt_rs::*;
 
 pub struct KeyExchangeSecP384r1 {
@@ -99,7 +102,7 @@ impl KeyExchangeSecP384r1 {
             wc_ecc_import_private_key_ex(
                 self.priv_key_bytes.as_ptr(),
                 self.priv_key_bytes.len() as word32,
-                std::ptr::null_mut(),
+                ptr::null_mut(),
                 0,
                 priv_key_object.as_ptr(),
                 ecc_curve_id_ECC_SECP384R1,
@@ -116,7 +119,7 @@ impl KeyExchangeSecP384r1 {
                 pub_key_object.as_ptr(),
                 peer_pub_key[1..49].as_ptr(),
                 peer_pub_key[49..].as_ptr(),
-                std::ptr::null_mut(),
+                ptr::null_mut(),
                 ecc_curve_id_ECC_SECP384R1,
             )
         };

--- a/rustls-wolfcrypt-provider/src/kx/sec521r1.rs
+++ b/rustls-wolfcrypt-provider/src/kx/sec521r1.rs
@@ -1,6 +1,9 @@
 use crate::{error::check_if_zero, types::types::*};
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::mem;
+use core::ptr;
 use foreign_types::ForeignType;
-use std::mem;
 use wolfcrypt_rs::*;
 
 pub struct KeyExchangeSecP521r1 {
@@ -101,7 +104,7 @@ impl KeyExchangeSecP521r1 {
             wc_ecc_import_private_key_ex(
                 self.priv_key_bytes.as_ptr(),
                 self.priv_key_bytes.len() as word32,
-                std::ptr::null_mut(),
+                ptr::null_mut(),
                 0,
                 priv_key_object.as_ptr(),
                 ecc_curve_id_ECC_SECP521R1,
@@ -118,7 +121,7 @@ impl KeyExchangeSecP521r1 {
                 pub_key_object.as_ptr(),
                 peer_pub_key[1..67].as_ptr(),
                 peer_pub_key[67..].as_ptr(),
-                std::ptr::null_mut(),
+                ptr::null_mut(),
                 ecc_curve_id_ECC_SECP521R1,
             )
         };

--- a/rustls-wolfcrypt-provider/src/kx/x25519.rs
+++ b/rustls-wolfcrypt-provider/src/kx/x25519.rs
@@ -1,6 +1,8 @@
 use crate::{error::check_if_zero, types::types::*};
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::mem;
 use foreign_types::ForeignType;
-use std::mem;
 use wolfcrypt_rs::*;
 
 pub struct KeyExchangeX25519 {

--- a/rustls-wolfcrypt-provider/src/lib.rs
+++ b/rustls-wolfcrypt-provider/src/lib.rs
@@ -1,7 +1,13 @@
-extern crate alloc;
+#![cfg_attr(not(feature = "std"), no_std)]
+
+// Conditionally include `std` if the `std` feature is enabled
+#[cfg(feature = "std")]
 extern crate std;
 
+extern crate alloc;
+
 use alloc::sync::Arc;
+use alloc::vec::Vec;
 use rustls::crypto::tls13::HkdfUsingHmac;
 use rustls::crypto::CryptoProvider;
 use rustls::pki_types::PrivateKeyDer;

--- a/rustls-wolfcrypt-provider/src/sign/ecdsa.rs
+++ b/rustls-wolfcrypt-provider/src/sign/ecdsa.rs
@@ -3,11 +3,12 @@ use crate::types::types::*;
 use alloc::boxed::Box;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
+use core::mem;
 use foreign_types::ForeignType;
 use rustls::pki_types::PrivateKeyDer;
 use rustls::sign::{Signer, SigningKey};
 use rustls::{SignatureAlgorithm, SignatureScheme};
-use std::mem;
+
 use wolfcrypt_rs::*;
 
 #[derive(Clone, Debug)]

--- a/rustls-wolfcrypt-provider/src/sign/rsapkcs1.rs
+++ b/rustls-wolfcrypt-provider/src/sign/rsapkcs1.rs
@@ -3,12 +3,13 @@ use crate::types::types::*;
 use alloc::boxed::Box;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
+use core::ffi::c_void;
+use core::mem;
+use core::ptr;
 use foreign_types::ForeignType;
 use rustls::pki_types::PrivateKeyDer;
 use rustls::sign::{Signer, SigningKey};
 use rustls::{SignatureAlgorithm, SignatureScheme};
-use std::ffi::c_void;
-use std::mem;
 use wolfcrypt_rs::*;
 
 #[derive(Clone, Debug)]
@@ -35,7 +36,7 @@ impl TryFrom<&PrivateKeyDer<'_>> for RsaPkcs1Sha256 {
                 let pkcs1_sz: word32 = pkcs1.len() as word32;
                 let mut ret;
 
-                ret = unsafe { wc_InitRsaKey(rsa_key_object.as_ptr(), std::ptr::null_mut()) };
+                ret = unsafe { wc_InitRsaKey(rsa_key_object.as_ptr(), ptr::null_mut()) };
                 check_if_zero(ret).unwrap();
 
                 let mut idx: u32 = 0;
@@ -139,7 +140,7 @@ impl TryFrom<&PrivateKeyDer<'_>> for RsaPkcs1Sha384 {
                 let pkcs1_sz: word32 = pkcs1.len() as word32;
                 let mut ret;
 
-                ret = unsafe { wc_InitRsaKey(rsa_key_object.as_ptr(), std::ptr::null_mut()) };
+                ret = unsafe { wc_InitRsaKey(rsa_key_object.as_ptr(), ptr::null_mut()) };
                 check_if_zero(ret).unwrap();
 
                 let mut idx: u32 = 0;
@@ -243,7 +244,7 @@ impl TryFrom<&PrivateKeyDer<'_>> for RsaPkcs1Sha512 {
                 let pkcs1_sz: word32 = pkcs1.len() as word32;
                 let mut ret;
 
-                ret = unsafe { wc_InitRsaKey(rsa_key_object.as_ptr(), std::ptr::null_mut()) };
+                ret = unsafe { wc_InitRsaKey(rsa_key_object.as_ptr(), ptr::null_mut()) };
                 check_if_zero(ret).unwrap();
 
                 let mut idx: u32 = 0;

--- a/rustls-wolfcrypt-provider/src/sign/rsapss.rs
+++ b/rustls-wolfcrypt-provider/src/sign/rsapss.rs
@@ -3,11 +3,13 @@ use crate::types::types::*;
 use alloc::boxed::Box;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
+use core::mem;
 use foreign_types::ForeignType;
 use rustls::pki_types::PrivateKeyDer;
 use rustls::sign::{Signer, SigningKey};
 use rustls::{SignatureAlgorithm, SignatureScheme};
-use std::mem;
+
+use core::ptr;
 use wolfcrypt_rs::*;
 
 #[derive(Clone, Debug)]
@@ -36,7 +38,7 @@ impl TryFrom<&PrivateKeyDer<'_>> for RsaPssSha256Sign {
                 let pkcs8_sz: word32 = pkcs8.len() as word32;
                 let mut ret;
 
-                ret = unsafe { wc_InitRsaKey(rsa_key_object.as_ptr(), std::ptr::null_mut()) };
+                ret = unsafe { wc_InitRsaKey(rsa_key_object.as_ptr(), ptr::null_mut()) };
                 check_if_zero(ret).unwrap();
 
                 let mut idx: u32 = 0;
@@ -143,7 +145,7 @@ impl TryFrom<&PrivateKeyDer<'_>> for RsaPssSha384Sign {
                 let pkcs8_sz: word32 = pkcs8.len() as word32;
                 let mut ret;
 
-                ret = unsafe { wc_InitRsaKey(rsa_key_object.as_ptr(), std::ptr::null_mut()) };
+                ret = unsafe { wc_InitRsaKey(rsa_key_object.as_ptr(), ptr::null_mut()) };
                 check_if_zero(ret).unwrap();
 
                 let mut idx: u32 = 0;
@@ -250,7 +252,7 @@ impl TryFrom<&PrivateKeyDer<'_>> for RsaPssSha512Sign {
                 let pkcs8_sz: word32 = pkcs8.len() as word32;
                 let mut ret;
 
-                ret = unsafe { wc_InitRsaKey(rsa_key_object.as_ptr(), std::ptr::null_mut()) };
+                ret = unsafe { wc_InitRsaKey(rsa_key_object.as_ptr(), ptr::null_mut()) };
                 check_if_zero(ret).unwrap();
 
                 let mut idx: u32 = 0;
@@ -347,7 +349,7 @@ mod tests {
         let mut final_output: [u8; 64] = [0; 64];
         let sz;
 
-        ret = unsafe { wc_InitRsaKey(rsa_key_object.as_ptr(), std::ptr::null_mut()) };
+        ret = unsafe { wc_InitRsaKey(rsa_key_object.as_ptr(), ptr::null_mut()) };
         check_if_zero(ret).unwrap();
 
         let mut rng_c_type: WC_RNG = unsafe { mem::zeroed() };

--- a/rustls-wolfcrypt-provider/src/types/types.rs
+++ b/rustls-wolfcrypt-provider/src/types/types.rs
@@ -1,6 +1,7 @@
 use crate::error::*;
+use core::ptr::NonNull;
 use foreign_types::{ForeignType, ForeignTypeRef, Opaque};
-use std::ptr::NonNull;
+
 use wolfcrypt_rs::*;
 
 macro_rules! define_foreign_type {

--- a/rustls-wolfcrypt-provider/src/verify/ecdsa.rs
+++ b/rustls-wolfcrypt-provider/src/verify/ecdsa.rs
@@ -2,9 +2,10 @@ use crate::{
     error::{check_if_one, check_if_zero, WCError},
     types::types::*,
 };
+use core::mem;
+use core::ptr;
 use foreign_types::ForeignType;
 use rustls::pki_types::{AlgorithmIdentifier, InvalidSignature, SignatureVerificationAlgorithm};
-use std::mem;
 use webpki::alg_id;
 use wolfcrypt_rs::*;
 
@@ -44,7 +45,7 @@ impl SignatureVerificationAlgorithm for EcdsaNistp256Sha256 {
                 ecc_object.as_ptr(),
                 public_key[1..33].as_ptr(), /* Public "x" Coordinate */
                 public_key[33..].as_ptr(),  /* Public "y" Coordinate */
-                std::ptr::null_mut(),       /* Private "d" (optional) */
+                ptr::null_mut(),            /* Private "d" (optional) */
                 ecc_curve_id_ECC_SECP256R1, /* ECC Curve Id */
             );
             check_if_zero(ret).unwrap();
@@ -122,7 +123,7 @@ impl SignatureVerificationAlgorithm for EcdsaNistp384Sha256 {
                 ecc_object.as_ptr(),
                 public_key[1..49].as_ptr(), /* Public "x" Coordinate */
                 public_key[49..].as_ptr(),  /* Public "y" Coordinate */
-                std::ptr::null_mut(),       /* Private "d" (optional) */
+                ptr::null_mut(),            /* Private "d" (optional) */
                 ecc_curve_id_ECC_SECP384R1, /* ECC Curve Id */
             );
             check_if_zero(ret).unwrap();
@@ -200,7 +201,7 @@ impl SignatureVerificationAlgorithm for EcdsaNistp256Sha384 {
                 ecc_object.as_ptr(),
                 public_key[1..33].as_ptr(), /* Public "x" Coordinate */
                 public_key[33..].as_ptr(),  /* Public "y" Coordinate */
-                std::ptr::null_mut(),       /* Private "d" (optional) */
+                ptr::null_mut(),            /* Private "d" (optional) */
                 ecc_curve_id_ECC_SECP256R1, /* ECC Curve Id */
             );
             check_if_zero(ret).unwrap();
@@ -278,7 +279,7 @@ impl SignatureVerificationAlgorithm for EcdsaNistp384Sha384 {
                 ecc_object.as_ptr(),
                 public_key[1..49].as_ptr(), /* Public "x" Coordinate */
                 public_key[49..].as_ptr(),  /* Public "y" Coordinate */
-                std::ptr::null_mut(),       /* Private "d" (optional) */
+                ptr::null_mut(),            /* Private "d" (optional) */
                 ecc_curve_id_ECC_SECP384R1, /* ECC Curve Id */
             );
             check_if_zero(ret).unwrap();
@@ -354,7 +355,7 @@ impl SignatureVerificationAlgorithm for EcdsaNistp521Sha512 {
                 ecc_object.as_ptr(),
                 public_key[1..67].as_ptr(), /* Public "x" Coordinate */
                 public_key[67..].as_ptr(),  /* Public "y" Coordinate */
-                std::ptr::null_mut(),       /* Private "d" (optional) */
+                ptr::null_mut(),            /* Private "d" (optional) */
                 ecc_curve_id_ECC_SECP521R1, /* ECC Curve Id */
             );
             check_if_zero(ret).unwrap();

--- a/rustls-wolfcrypt-provider/src/verify/rsapkcs1.rs
+++ b/rustls-wolfcrypt-provider/src/verify/rsapkcs1.rs
@@ -1,12 +1,14 @@
 use crate::error::check_if_zero;
 use crate::error::*;
 use crate::types::types::*;
+use core::ffi::c_void;
+use core::mem;
 use der::Reader;
 use foreign_types::ForeignType;
 use rsa::BigUint;
 use rustls::pki_types::{AlgorithmIdentifier, InvalidSignature, SignatureVerificationAlgorithm};
-use std::ffi::c_void;
-use std::mem;
+
+use core::ptr;
 use webpki::alg_id;
 use wolfcrypt_rs::*;
 
@@ -113,7 +115,7 @@ fn wc_decode_spki_spk(spki_spk: &[u8]) -> Result<RsaKey, InvalidSignature> {
 
     // This function initializes a provided RsaKey struct. It also takes in a heap identifier,
     // for use with user defined memory overrides (see XMALLOC, XFREE, XREALLOC).
-    ret = unsafe { wc_InitRsaKey(rsa_key_object.as_ptr(), std::ptr::null_mut()) };
+    ret = unsafe { wc_InitRsaKey(rsa_key_object.as_ptr(), ptr::null_mut()) };
     check_if_zero(ret).unwrap();
 
     // This function decodes the raw elements of an RSA public key, taking in

--- a/rustls-wolfcrypt-provider/src/verify/rsapss.rs
+++ b/rustls-wolfcrypt-provider/src/verify/rsapss.rs
@@ -1,11 +1,12 @@
 use crate::error::*;
 use crate::types::types::*;
+use alloc::vec::Vec;
+use core::mem;
+use core::ptr;
 use der::Reader;
 use foreign_types::ForeignType;
 use rsa::BigUint;
 use rustls::pki_types::{AlgorithmIdentifier, InvalidSignature, SignatureVerificationAlgorithm};
-use std::mem;
-use std::vec::Vec;
 use webpki::alg_id;
 use wolfcrypt_rs::*;
 
@@ -165,7 +166,7 @@ fn wc_decode_spki_spk(spki_spk: &[u8]) -> Result<RsaKey, InvalidSignature> {
 
     // This function initializes a provided RsaKey struct. It also takes in a heap identifier,
     // for use with user defined memory overrides (see XMALLOC, XFREE, XREALLOC).
-    ret = unsafe { wc_InitRsaKey(rsa_key_object.as_ptr(), std::ptr::null_mut()) };
+    ret = unsafe { wc_InitRsaKey(rsa_key_object.as_ptr(), ptr::null_mut()) };
     check_if_zero(ret).unwrap();
 
     // This function decodes the raw elements of an RSA public key, taking in

--- a/wolfcrypt-rs/Cargo.toml
+++ b/wolfcrypt-rs/Cargo.toml
@@ -3,5 +3,8 @@ name = "wolfcrypt-rs"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+std = []
+
 [build-dependencies]
 bindgen = "0.70.1"

--- a/wolfcrypt-rs/src/lib.rs
+++ b/wolfcrypt-rs/src/lib.rs
@@ -4,6 +4,8 @@ pub use bindings::*;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use core::mem;
+    use core::ffi::c_int;
 
 
     #[test]

--- a/wolfcrypt-rs/src/lib.rs
+++ b/wolfcrypt-rs/src/lib.rs
@@ -4,7 +4,7 @@ pub use bindings::*;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{ffi::c_int, mem};
+
 
     #[test]
     fn rsa_encrypt_decrypt() {


### PR DESCRIPTION
This pull request focuses on adding `no_std` support to the `rustls-wolfcrypt-provider` crate by removing dependencies on the `std` library and replacing them with `core` and `alloc` where necessary. The changes span multiple files, primarily involving imports and initializations,.