### PR TITLE
HKDF and PRF traits backed by wolfcrypt

### DIFF
--- a/rustls-wolfcrypt-provider/Cargo.lock
+++ b/rustls-wolfcrypt-provider/Cargo.lock
@@ -291,6 +291,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
+
+[[package]]
 name = "der"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -493,6 +499,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -536,6 +548,12 @@ checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "jobserver"
@@ -1041,6 +1059,7 @@ dependencies = [
  "env_logger",
  "foreign-types",
  "hex",
+ "hex-literal",
  "hmac",
  "log",
  "pkcs8",
@@ -1057,7 +1076,14 @@ dependencies = [
  "tokio",
  "webpki-roots",
  "wolfcrypt-rs",
+ "wycheproof",
 ]
+
+[[package]]
+name = "ryu"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "scc"
@@ -1112,6 +1138,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.134"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d00f4175c42ee48b15416f6193a959ba3a0d67fc699a0db9ad12df9f83991c7d"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -1398,6 +1436,17 @@ name = "wolfcrypt-rs"
 version = "0.1.0"
 dependencies = [
  "bindgen 0.70.1",
+]
+
+[[package]]
+name = "wycheproof"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efb3be19abfb206c6adcbdf2007b09b0e8ca1f6530db40c03b42ce8ed4719894"
+dependencies = [
+ "data-encoding",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/rustls-wolfcrypt-provider/Cargo.toml
+++ b/rustls-wolfcrypt-provider/Cargo.toml
@@ -22,6 +22,8 @@ env_logger = { version = "0.11.5", default-features = false }
 wolfcrypt-rs = { path = "../wolfcrypt-rs" }
 rustls-pemfile = { version = "2.2.0", default-features = false }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"]} 
+wycheproof = "0.6.0"
+hex-literal = "0.4.1"
 
 [dev-dependencies]
 rcgen = { version = "0.13" }

--- a/rustls-wolfcrypt-provider/src/hkdf.rs
+++ b/rustls-wolfcrypt-provider/src/hkdf.rs
@@ -1,0 +1,274 @@
+use rustls::crypto::tls13::{self, Hkdf as RustlsHkdf};
+use alloc::boxed::Box;
+use alloc::vec;
+use core::mem;
+use alloc::vec::Vec;
+use wolfcrypt_rs::*;
+
+use crate::error::check_if_zero;
+use crate::hmac::hmac::WCShaHmac;
+
+pub struct WCHkdfUsingHmac(pub WCShaHmac);
+
+impl RustlsHkdf for WCHkdfUsingHmac {
+    fn extract_from_zero_ikm(
+        &self,
+        salt: Option<&[u8]>,
+    ) -> Box<dyn rustls::crypto::tls13::HkdfExpander> {
+        let hash_len = self.0.hash_len();
+        let ikm = vec![0u8; hash_len];
+        self.extract_from_secret(salt, &ikm)
+    }
+
+    fn extract_from_secret(
+        &self,
+        salt: Option<&[u8]>,
+        ikm: &[u8],
+    ) -> Box<dyn rustls::crypto::tls13::HkdfExpander> {
+        let hash_len = self.0.hash_len();
+        let mut extracted_key = vec![0u8; hash_len];
+        let zero_salt = vec![0u8; hash_len];
+        let salt_bytes = salt.unwrap_or(&zero_salt);
+
+        let ret = unsafe {
+            wc_HKDF_Extract(
+                self.0.hash_type().try_into().unwrap(),
+                salt_bytes.as_ptr(),
+                salt_bytes.len() as u32,
+                ikm.as_ptr(),
+                ikm.len() as u32,
+                extracted_key.as_mut_ptr(),
+            )
+        };
+        check_if_zero(ret).unwrap();
+
+        Box::new(WolfHkdfExpander::new(extracted_key, self.0.hash_type().try_into().unwrap(), self.0.hash_len()))
+    }
+
+    fn expander_for_okm(
+        &self,
+        okm: &rustls::crypto::tls13::OkmBlock,
+    ) -> Box<dyn rustls::crypto::tls13::HkdfExpander> {
+        Box::new(WolfHkdfExpander {
+            extracted_key: okm.as_ref().to_vec(),
+            hash_type: self.0.hash_type().try_into().unwrap(),
+            hash_len: self.0.hash_len(),
+        })
+    }
+
+    fn hmac_sign(
+        &self,
+        key: &rustls::crypto::tls13::OkmBlock,
+        message: &[u8],
+    ) -> rustls::crypto::hmac::Tag {
+        let mut hmac = vec![0u8; self.0.hash_len()];
+        let mut hmac_ctx = unsafe { mem::zeroed() };
+
+        let mut ret = unsafe {
+            wc_HmacSetKey(
+                &mut hmac_ctx,
+                self.0.hash_type().try_into().unwrap(),
+                key.as_ref().as_ptr(),
+                key.as_ref().len() as u32,
+            )
+        };
+        check_if_zero(ret).unwrap();
+
+        ret = unsafe {
+            wc_HmacUpdate(
+                &mut hmac_ctx,
+                message.as_ptr(),
+                message.len() as u32,
+            )
+        };
+        check_if_zero(ret).unwrap();
+
+        ret = unsafe {
+            wc_HmacFinal(
+                &mut hmac_ctx,
+                hmac.as_mut_ptr(),
+            )
+        };
+        check_if_zero(ret).unwrap();
+
+        unsafe {
+            wc_HmacFree(
+                &mut hmac_ctx,
+            )
+        };
+        check_if_zero(ret).unwrap();
+
+        rustls::crypto::hmac::Tag::new(&hmac)
+    }
+}
+
+/// Expander implementation that holds the extracted key material from HKDF extract phase
+struct WolfHkdfExpander {
+    extracted_key: Vec<u8>,  // The pseudorandom key (PRK) output from HKDF-Extract
+    hash_type: i32,         // The wolfSSL hash algorithm identifier
+    hash_len: usize,       // Length of the hash function output
+}
+
+impl WolfHkdfExpander {
+    fn new(extracted_key: Vec<u8>, hash_type: i32, hash_len: usize) -> Self {
+        Self {
+            extracted_key,
+            hash_type,
+            hash_len,
+        }
+    }
+}
+
+impl tls13::HkdfExpander for WolfHkdfExpander {
+    fn expand_slice(
+        &self,
+        info: &[&[u8]],
+        output: &mut [u8],
+    ) -> Result<(), tls13::OutputLengthError> {
+        let info_concat = info.concat();
+        
+        if output.len() > 255 * self.hash_len {
+            return Err(tls13::OutputLengthError);
+        }
+
+        unsafe {
+            wc_HKDF_Expand(
+                self.hash_type,
+                self.extracted_key.as_ptr(),
+                self.extracted_key.len() as u32,
+                info_concat.as_ptr(),
+                info_concat.len() as u32,
+                output.as_mut_ptr(),
+                output.len() as u32,
+            );
+        }
+        
+        Ok(())
+    }
+
+    fn expand_block(&self, info: &[&[u8]]) -> tls13::OkmBlock {
+        let mut output = vec![0u8; self.hash_len];
+        self.expand_slice(info, &mut output)
+            .expect("expand_block failed");
+        tls13::OkmBlock::new(&output)
+    }
+
+    fn hash_len(&self) -> usize {
+        self.hash_len
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hex_literal::hex;
+
+    /// Tests the HKDF implementation against RFC 5869 test vector A.1
+    /// This is the primary compliance test using SHA-256
+    #[test]
+    fn test_hkdf_sha256() {
+        // Test vectors from RFC 5869 Appendix A.1
+        let ikm = hex!("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");
+        let salt = hex!("000102030405060708090a0b0c");
+        let info = hex!("f0f1f2f3f4f5f6f7f8f9");
+        let expected_okm = hex!(
+            "3cb25f25faacd57a90434f64d0362f2a"
+            "2d2d0a90cf1a5a4c5db02d56ecc4c5bf"
+            "34007208d5b887185865"
+        );
+
+        let hkdf = WCHkdfUsingHmac(WCShaHmac::new(wc_HashType_WC_HASH_TYPE_SHA256));
+        let expander = hkdf.extract_from_secret(Some(&salt), &ikm);
+        
+        let mut okm = vec![0u8; 42]; // Length from test vector
+        expander.expand_slice(&[&info], &mut okm).unwrap();
+        
+        assert_eq!(&okm[..], &expected_okm[..]);
+    }
+
+    /// Tests HKDF with SHA-384 to ensure it works with different hash functions
+    /// Note: This test doesn't verify against RFC test vectors
+    #[test]
+    fn test_hkdf_sha384() {
+        // Test with SHA384
+        let ikm = hex!("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");
+        let salt = hex!("000102030405060708090a0b0c");
+        let info = hex!("f0f1f2f3f4f5f6f7f8f9");
+        
+        let hkdf = WCHkdfUsingHmac(WCShaHmac::new(wc_HashType_WC_HASH_TYPE_SHA384));
+        let expander = hkdf.extract_from_secret(Some(&salt), &ikm);
+        
+        let mut okm = vec![0u8; 48]; // SHA384 output length
+        expander.expand_slice(&[&info], &mut okm).unwrap();
+        
+        // Just verify we can generate output - actual value would need a verified test vector
+        assert!(!okm.iter().all(|&x| x == 0));
+    }
+
+    /// Verifies that the HKDF implementation correctly enforces the output length limit
+    /// The limit is 255 times the hash length as specified in RFC 5869
+    #[test]
+    fn test_hkdf_output_length_limit() {
+        let hkdf = WCHkdfUsingHmac(WCShaHmac::new(wc_HashType_WC_HASH_TYPE_SHA256));
+        let expander = hkdf.extract_from_zero_ikm(None);
+        
+        // Maximum allowed length (255 * hash_len)
+        let max_len = 255 * 32;
+        let mut okm = vec![0u8; max_len];
+        assert!(expander.expand_slice(&[&[]], &mut okm).is_ok());
+        
+        // Exceeding maximum length should fail
+        let mut okm = vec![0u8; max_len + 1];
+        assert!(expander.expand_slice(&[&[]], &mut okm).is_err());
+    }
+
+    /// Tests the special case of zero input key material
+    /// This is important for TLS 1.3 which sometimes requires derivation from zero IKM
+    #[test]
+    fn test_hkdf_zero_ikm() {
+        let hkdf = WCHkdfUsingHmac(WCShaHmac::new(wc_HashType_WC_HASH_TYPE_SHA256));
+        let salt = hex!("000102030405060708090a0b0c");
+        let info = hex!("f0f1f2f3f4f5f6f7f8f9");
+        
+        let expander = hkdf.extract_from_zero_ikm(Some(&salt));
+        
+        let mut okm1 = vec![0u8; 32];
+        expander.expand_slice(&[&info], &mut okm1).unwrap();
+        
+        // Verify that zero IKM produces consistent output
+        let expander2 = hkdf.extract_from_zero_ikm(Some(&salt));
+        let mut okm2 = vec![0u8; 32];
+        expander2.expand_slice(&[&info], &mut okm2).unwrap();
+        
+        assert_eq!(okm1, okm2);
+    }
+
+    /// Tests that the implementation correctly handles multiple info components
+    /// Verifies that passing multiple info slices produces the same result as their concatenation
+    #[test]
+    fn test_hkdf_multiple_info_components() {
+        let hkdf = WCHkdfUsingHmac(WCShaHmac::new(wc_HashType_WC_HASH_TYPE_SHA256));
+        let salt = hex!("000102030405060708090a0b0c");
+        let info1 = hex!("f0f1f2f3");
+        let info2 = hex!("f4f5f6f7");
+        let info3 = hex!("f8f9");
+        
+        let expander = hkdf.extract_from_zero_ikm(Some(&salt));
+        
+        // Test with multiple info components
+        let mut okm1 = vec![0u8; 32];
+        expander.expand_slice(&[&info1, &info2, &info3], &mut okm1).unwrap();
+        
+        // Test with concatenated info
+        let mut info_concat = Vec::new();
+        info_concat.extend_from_slice(&info1);
+        info_concat.extend_from_slice(&info2);
+        info_concat.extend_from_slice(&info3);
+        
+        let mut okm2 = vec![0u8; 32];
+        expander.expand_slice(&[&info_concat], &mut okm2).unwrap();
+        
+        // Results should be identical
+        assert_eq!(okm1, okm2);
+    }
+}

--- a/rustls-wolfcrypt-provider/src/hmac/hmac.rs
+++ b/rustls-wolfcrypt-provider/src/hmac/hmac.rs
@@ -1,0 +1,104 @@
+use crate::{error::check_if_zero, types::types::*};
+use alloc::{boxed::Box, vec::Vec, vec};
+use core::mem;
+use foreign_types::ForeignType;
+use rustls::crypto;
+use wolfcrypt_rs::*;
+
+#[derive(Clone, Copy)]
+pub enum WCShaHmac {
+    Sha256,
+    Sha384,
+}
+
+impl WCShaHmac {
+    fn digest_size(&self) -> usize {
+        match self {
+            WCShaHmac::Sha256 => WC_SHA256_DIGEST_SIZE as usize,
+            WCShaHmac::Sha384 => WC_SHA384_DIGEST_SIZE as usize,
+        }
+    }
+
+    fn algorithm(&self) -> i32 {
+        match self {
+            WCShaHmac::Sha256 => WC_SHA256.try_into().unwrap(),
+            WCShaHmac::Sha384 => WC_SHA384.try_into().unwrap(),
+        }
+    }
+}
+
+impl crypto::hmac::Hmac for WCShaHmac {
+    fn with_key(&self, key: &[u8]) -> Box<dyn crypto::hmac::Key> {
+        Box::new(WCHmacKey {
+            key: key.to_vec(),
+            variant: *self,
+        })
+    }
+
+    fn hash_output_len(&self) -> usize {
+        self.digest_size()
+    }
+}
+
+struct WCHmacKey {
+    key: Vec<u8>,
+    variant: WCShaHmac,
+}
+
+impl crypto::hmac::Key for WCHmacKey {
+    fn sign_concat(&self, first: &[u8], middle: &[&[u8]], last: &[u8]) -> crypto::hmac::Tag {
+        let hmac_object = self.hmac_init();
+        self.hmac_update(hmac_object, first);
+        for m in middle {
+            self.hmac_update(hmac_object, m)
+        }
+        self.hmac_update(hmac_object, last);
+        let digest = self.hmac_final(hmac_object);
+        crypto::hmac::Tag::new(&digest)
+    }
+
+    fn tag_len(&self) -> usize {
+        self.variant.digest_size()
+    }
+}
+
+impl WCHmacKey {
+    fn hmac_init(&self) -> HmacObject {
+        let mut hmac_c_type: Hmac = unsafe { mem::zeroed() };
+        let hmac_object = unsafe { HmacObject::from_ptr(&mut hmac_c_type) };
+
+        let ret = unsafe {
+            wc_HmacSetKey(
+                hmac_object.as_ptr(),
+                self.variant.algorithm(),
+                self.key.as_ptr(),
+                self.key.len() as word32,
+            )
+        };
+        check_if_zero(ret).unwrap();
+        hmac_object
+    }
+
+    fn hmac_update(&self, hmac_object: HmacObject, input: &[u8]) {
+        let ret = unsafe { 
+            wc_HmacUpdate(
+                hmac_object.as_ptr(),
+                input.as_ptr(),
+                input.len() as word32
+            )
+        };
+        check_if_zero(ret).unwrap();
+    }
+
+    fn hmac_final(&self, hmac_object: HmacObject) -> Vec<u8> {
+        let mut digest = vec![0u8; self.variant.digest_size()];
+        let ret = unsafe { 
+            wc_HmacFinal(
+                hmac_object.as_ptr(),
+                digest.as_mut_ptr()
+            )
+        };
+        check_if_zero(ret).unwrap();
+        digest
+    }
+}

--- a/rustls-wolfcrypt-provider/src/hmac/hmac.rs
+++ b/rustls-wolfcrypt-provider/src/hmac/hmac.rs
@@ -25,6 +25,28 @@ impl WCShaHmac {
             WCShaHmac::Sha384 => WC_SHA384.try_into().unwrap(),
         }
     }
+
+    pub fn new(hash_type: wc_HashType) -> Self {
+        match hash_type {
+            WC_SHA256 => WCShaHmac::Sha256,
+            WC_SHA384 => WCShaHmac::Sha384,
+            _ => panic!("Unsupported hash type"),
+        }
+    }
+
+    pub fn hash_type(&self) -> wc_HashType {
+        match self {
+            WCShaHmac::Sha256 => WC_SHA256,
+            WCShaHmac::Sha384 => WC_SHA384,
+        }
+    }
+
+    pub fn hash_len(&self) -> usize {
+        match self {
+            WCShaHmac::Sha256 => WC_SHA256_DIGEST_SIZE as usize,
+            WCShaHmac::Sha384 => WC_SHA384_DIGEST_SIZE as usize,
+        }
+    }
 }
 
 impl crypto::hmac::Hmac for WCShaHmac {

--- a/rustls-wolfcrypt-provider/src/lib.rs
+++ b/rustls-wolfcrypt-provider/src/lib.rs
@@ -15,6 +15,7 @@ mod kx;
 mod random;
 mod verify;
 mod prf;
+use crate::prf::WCPrfUsingHmac;
 pub mod aead {
     pub mod aes128gcm;
     pub mod aes256gcm;
@@ -34,11 +35,12 @@ pub mod hash {
 use crate::hash::{sha256, sha384};
 
 pub mod hmac {
-    pub mod sha256hmac;
-    pub mod sha384hmac;
+    pub mod hmac;
 }
-use crate::hmac::{sha256hmac, sha384hmac};
-mod types {
+
+use crate::hmac::hmac::WCShaHmac;
+
+pub mod types {
     pub mod types;
 }
 
@@ -150,7 +152,7 @@ pub static TLS13_CHACHA20_POLY1305_SHA256: rustls::SupportedCipherSuite =
             hash_provider: &sha256::WCSha256,
             confidentiality_limit: u64::MAX,
         },
-        hkdf_provider: &HkdfUsingHmac(&sha256hmac::WCSha256Hmac),
+        hkdf_provider: &HkdfUsingHmac(&WCShaHmac::Sha256),
         aead_alg: &chacha20::Chacha20Poly1305,
         quic: None,
     });
@@ -162,7 +164,7 @@ pub static TLS13_AES_128_GCM_SHA256: rustls::SupportedCipherSuite =
             hash_provider: &sha256::WCSha256,
             confidentiality_limit: 1 << 23,
         },
-        hkdf_provider: &HkdfUsingHmac(&sha256hmac::WCSha256Hmac),
+        hkdf_provider: &HkdfUsingHmac(&WCShaHmac::Sha256),
         aead_alg: &aes128gcm::Aes128Gcm,
         quic: None,
     });
@@ -174,7 +176,7 @@ pub static TLS13_AES_256_GCM_SHA384: rustls::SupportedCipherSuite =
             hash_provider: &sha384::WCSha384,
             confidentiality_limit: 1 << 23,
         },
-        hkdf_provider: &HkdfUsingHmac(&sha384hmac::WCSha384Hmac),
+        hkdf_provider: &HkdfUsingHmac(&WCShaHmac::Sha384),
         aead_alg: &aes256gcm::Aes256Gcm,
         quic: None,
     });
@@ -187,7 +189,7 @@ pub static TLS12_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256: rustls::SupportedCiphe
             confidentiality_limit: u64::MAX,
         },
         aead_alg: &chacha20::Chacha20Poly1305,
-        prf_provider: &rustls::crypto::tls12::PrfUsingHmac(&sha256hmac::WCSha256Hmac),
+        prf_provider: &WCPrfUsingHmac(WCShaHmac::Sha256),
         kx: rustls::crypto::KeyExchangeAlgorithm::ECDHE,
         sign: ALL_RSA_SCHEMES,
     });
@@ -200,7 +202,7 @@ pub static TLS12_ECDHE_RSA_WITH_AES_128_GCM_SHA256: rustls::SupportedCipherSuite
             confidentiality_limit: 1 << 23,
         },
         aead_alg: &aes128gcm::Aes128Gcm,
-        prf_provider: &rustls::crypto::tls12::PrfUsingHmac(&sha256hmac::WCSha256Hmac),
+        prf_provider: &WCPrfUsingHmac(WCShaHmac::Sha256),
         kx: rustls::crypto::KeyExchangeAlgorithm::ECDHE,
         sign: ALL_RSA_SCHEMES,
     });
@@ -213,7 +215,7 @@ pub static TLS12_ECDHE_RSA_WITH_AES_256_GCM_SHA384: rustls::SupportedCipherSuite
             confidentiality_limit: 1 << 23,
         },
         aead_alg: &aes256gcm::Aes256Gcm,
-        prf_provider: &rustls::crypto::tls12::PrfUsingHmac(&sha384hmac::WCSha384Hmac),
+        prf_provider: &WCPrfUsingHmac(WCShaHmac::Sha384),
         kx: rustls::crypto::KeyExchangeAlgorithm::ECDHE,
         sign: ALL_RSA_SCHEMES,
     });
@@ -225,7 +227,7 @@ pub static TLS12_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256: rustls::SupportedCip
             hash_provider: &sha256::WCSha256,
             confidentiality_limit: u64::MAX,
         },
-        prf_provider: &rustls::crypto::tls12::PrfUsingHmac(&sha256hmac::WCSha256Hmac),
+        prf_provider: &WCPrfUsingHmac(WCShaHmac::Sha256),
         kx: rustls::crypto::KeyExchangeAlgorithm::ECDHE,
         sign: ALL_ECDSA_SCHEMES,
         aead_alg: &chacha20::Chacha20Poly1305,
@@ -239,7 +241,7 @@ pub static TLS12_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256: rustls::SupportedCipherSui
             confidentiality_limit: 1 << 23,
         },
         aead_alg: &aes128gcm::Aes128Gcm,
-        prf_provider: &rustls::crypto::tls12::PrfUsingHmac(&sha256hmac::WCSha256Hmac),
+        prf_provider: &WCPrfUsingHmac(WCShaHmac::Sha256),
         kx: rustls::crypto::KeyExchangeAlgorithm::ECDHE,
         sign: ALL_ECDSA_SCHEMES,
     });
@@ -252,7 +254,7 @@ pub static TLS12_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384: rustls::SupportedCipherSui
             confidentiality_limit: 1 << 23,
         },
         aead_alg: &aes256gcm::Aes256Gcm,
-        prf_provider: &rustls::crypto::tls12::PrfUsingHmac(&sha384hmac::WCSha384Hmac),
+        prf_provider: &WCPrfUsingHmac(WCShaHmac::Sha384),
         kx: rustls::crypto::KeyExchangeAlgorithm::ECDHE,
         sign: ALL_ECDSA_SCHEMES,
     });

--- a/rustls-wolfcrypt-provider/src/lib.rs
+++ b/rustls-wolfcrypt-provider/src/lib.rs
@@ -7,7 +7,6 @@ extern crate alloc;
 
 use alloc::sync::Arc;
 use alloc::vec::Vec;
-use rustls::crypto::tls13::HkdfUsingHmac;
 use rustls::crypto::CryptoProvider;
 use rustls::pki_types::PrivateKeyDer;
 mod error;
@@ -15,7 +14,9 @@ mod kx;
 mod random;
 mod verify;
 mod prf;
+mod hkdf;
 use crate::prf::WCPrfUsingHmac;
+use crate::hkdf::WCHkdfUsingHmac;
 pub mod aead {
     pub mod aes128gcm;
     pub mod aes256gcm;
@@ -152,7 +153,7 @@ pub static TLS13_CHACHA20_POLY1305_SHA256: rustls::SupportedCipherSuite =
             hash_provider: &sha256::WCSha256,
             confidentiality_limit: u64::MAX,
         },
-        hkdf_provider: &HkdfUsingHmac(&WCShaHmac::Sha256),
+        hkdf_provider: &WCHkdfUsingHmac(WCShaHmac::Sha256),
         aead_alg: &chacha20::Chacha20Poly1305,
         quic: None,
     });
@@ -164,7 +165,7 @@ pub static TLS13_AES_128_GCM_SHA256: rustls::SupportedCipherSuite =
             hash_provider: &sha256::WCSha256,
             confidentiality_limit: 1 << 23,
         },
-        hkdf_provider: &HkdfUsingHmac(&WCShaHmac::Sha256),
+        hkdf_provider: &WCHkdfUsingHmac(WCShaHmac::Sha256),
         aead_alg: &aes128gcm::Aes128Gcm,
         quic: None,
     });
@@ -176,7 +177,7 @@ pub static TLS13_AES_256_GCM_SHA384: rustls::SupportedCipherSuite =
             hash_provider: &sha384::WCSha384,
             confidentiality_limit: 1 << 23,
         },
-        hkdf_provider: &HkdfUsingHmac(&WCShaHmac::Sha384),
+        hkdf_provider: &WCHkdfUsingHmac(WCShaHmac::Sha384),
         aead_alg: &aes256gcm::Aes256Gcm,
         quic: None,
     });

--- a/rustls-wolfcrypt-provider/src/lib.rs
+++ b/rustls-wolfcrypt-provider/src/lib.rs
@@ -14,6 +14,7 @@ mod error;
 mod kx;
 mod random;
 mod verify;
+mod prf;
 pub mod aead {
     pub mod aes128gcm;
     pub mod aes256gcm;

--- a/rustls-wolfcrypt-provider/src/prf.rs
+++ b/rustls-wolfcrypt-provider/src/prf.rs
@@ -1,0 +1,124 @@
+use rustls::crypto;
+use alloc::boxed::Box;
+use wolfcrypt_rs::*;
+
+use crate::error::check_if_zero;
+
+pub struct WCPrfUsingHmac;
+
+impl crypto::tls12::Prf for  WCPrfUsingHmac {
+    fn for_key_exchange(
+        &self,
+        output: &mut [u8; 48],
+        kx: Box<dyn crypto::ActiveKeyExchange>,
+        peer_pub_key: &[u8],
+        label: &[u8],
+        seed: &[u8],
+    ) -> Result<(), rustls::Error> {
+        let secret = kx.complete(peer_pub_key)?;
+
+        Ok(wc_prf(output, secret.secret_bytes(), label, seed)?)
+    }
+
+    fn for_secret(
+       &self,
+       output: &mut [u8],
+       secret: &[u8],
+       label: &[u8],
+       seed: &[u8]) -> () {
+        wc_prf(output, secret, label, seed)
+            .expect("failed to calculate prf in for_secret")
+    }
+}
+
+fn wc_prf(
+   output: &mut [u8],
+   secret: &[u8],
+   label: &[u8],
+   seed: &[u8],
+) -> Result<(), rustls::Error> {
+        let ret;
+
+        ret = unsafe {
+            wc_PRF_TLS(
+                output.as_mut_ptr(),
+                output.len() as word32,
+                secret.as_ptr(),
+                secret.len() as word32,
+                label.as_ptr(),
+                label.len() as word32,
+                seed.as_ptr(),
+                seed.len() as word32,
+                1,
+                wc_MACAlgorithm_sha256_mac.try_into().unwrap(),
+                core::ptr::null_mut(),
+                INVALID_DEVID
+            )
+        };
+
+        check_if_zero(ret).unwrap();
+        Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::mem;
+
+    #[test]
+    fn test_prf_using_hmac() {
+        unsafe {
+            let pre_master_secret = "D06F9C19BFF49B1E91E4EFE97345D0894E6C2E6C34A165B24540E2970875D6412AA6515871B389B4C199BB8389C71CED".as_bytes();
+            let hello_random     = "162B81EDFBEAE4F25240320B87E7651C865564191DD782DB0B9ECA275FBA1BB95A1DA3DF436D68DA86C5E7B4B4A36E46B977C61767983A31BE270D74517BD0F6".as_bytes();
+            let master_secret    = "EB38B8D89B98B1C266DE44BB3CA14E83C32F009F9955B1D994E61D3C51EE876090B4EF89CC7AF42F46E72201BFCC7977".as_bytes();
+            let mut label = "master secret".as_bytes();
+
+            let mut pms: [u8; 48] = mem::zeroed();
+            let mut seed: [u8; 64] = mem::zeroed();
+            let mut ms: [u8; 48] = mem::zeroed();
+            let mut result: [u8; 48] = mem::zeroed();
+
+            let pre_master_secret_len: word32 = pre_master_secret.len() as word32;
+            let mut pms_sz: word32 = pms.len() as word32;
+            let mut seed_sz: word32 = seed.len() as word32;
+            let mut ms_sz: word32 = ms.len() as word32;
+            let mut ret;
+
+            ret = Base16_Decode(
+                pre_master_secret.as_ptr(),
+                pre_master_secret_len, 
+                pms.as_mut_ptr(), 
+                &mut pms_sz as *mut u32);
+            if ret != 0 {
+                panic!("failed while calling Base16_Decode, with ret value: {}", ret);
+            }
+
+            ret = Base16_Decode(
+                hello_random.as_ptr(),
+                hello_random.len() as word32, 
+                seed.as_mut_ptr(), 
+                &mut seed_sz as *mut u32);
+            if ret != 0 {
+                panic!("failed while calling Base16_Decode, with ret value: {}", ret);
+            }
+
+            ret = Base16_Decode(
+                master_secret.as_ptr(),
+                master_secret.len() as word32, 
+                ms.as_mut_ptr(), 
+                &mut ms_sz as *mut u32);
+            if ret != 0 {
+                panic!("failed while calling Base16_Decode, with ret value: {}", ret);
+            }
+
+            wc_prf(
+                &mut result,
+                &mut pms,
+                &mut label,
+                &mut seed
+            ).unwrap();
+
+            assert_eq!(result, ms);
+        }
+    }
+}

--- a/rustls-wolfcrypt-provider/src/prf.rs
+++ b/rustls-wolfcrypt-provider/src/prf.rs
@@ -3,10 +3,12 @@ use alloc::boxed::Box;
 use wolfcrypt_rs::*;
 
 use crate::error::check_if_zero;
+use crate::hmac::hmac::*;
 
-pub struct WCPrfUsingHmac;
 
-impl crypto::tls12::Prf for  WCPrfUsingHmac {
+pub struct WCPrfUsingHmac(pub WCShaHmac);
+
+impl crypto::tls12::Prf for WCPrfUsingHmac {
     fn for_key_exchange(
         &self,
         output: &mut [u8; 48],
@@ -16,109 +18,95 @@ impl crypto::tls12::Prf for  WCPrfUsingHmac {
         seed: &[u8],
     ) -> Result<(), rustls::Error> {
         let secret = kx.complete(peer_pub_key)?;
-
-        Ok(wc_prf(output, secret.secret_bytes(), label, seed)?)
+        Ok(wc_prf(output, secret.secret_bytes(), label, seed, self.0)?)
     }
 
     fn for_secret(
-       &self,
-       output: &mut [u8],
-       secret: &[u8],
-       label: &[u8],
-       seed: &[u8]) -> () {
-        wc_prf(output, secret, label, seed)
+        &self,
+        output: &mut [u8],
+        secret: &[u8],
+        label: &[u8],
+        seed: &[u8]
+    ) -> () {
+        wc_prf(output, secret, label, seed, self.0)
             .expect("failed to calculate prf in for_secret")
     }
 }
 
 fn wc_prf(
-   output: &mut [u8],
-   secret: &[u8],
-   label: &[u8],
-   seed: &[u8],
+    output: &mut [u8],
+    secret: &[u8],
+    label: &[u8],
+    seed: &[u8],
+    hmac_variant: WCShaHmac,
 ) -> Result<(), rustls::Error> {
-        let ret;
+    let mac_algorithm = match hmac_variant {
+        WCShaHmac::Sha256 => wc_MACAlgorithm_sha256_mac,
+        WCShaHmac::Sha384 => wc_MACAlgorithm_sha384_mac,
+    };
 
-        ret = unsafe {
-            wc_PRF_TLS(
-                output.as_mut_ptr(),
-                output.len() as word32,
-                secret.as_ptr(),
-                secret.len() as word32,
-                label.as_ptr(),
-                label.len() as word32,
-                seed.as_ptr(),
-                seed.len() as word32,
-                1,
-                wc_MACAlgorithm_sha256_mac.try_into().unwrap(),
-                core::ptr::null_mut(),
-                INVALID_DEVID
-            )
-        };
+    let ret = unsafe {
+        wc_PRF_TLS(
+            output.as_mut_ptr(),
+            output.len() as word32,
+            secret.as_ptr(),
+            secret.len() as word32,
+            label.as_ptr(),
+            label.len() as word32,
+            seed.as_ptr(),
+            seed.len() as word32,
+            1,
+            mac_algorithm.try_into().unwrap(),
+            core::ptr::null_mut(),
+            INVALID_DEVID
+        )
+    };
 
-        check_if_zero(ret).unwrap();
-        Ok(())
+    check_if_zero(ret).unwrap();
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use core::mem;
+    use rustls::crypto::hmac::Hmac;
 
     #[test]
-    fn test_prf_using_hmac() {
-        unsafe {
-            let pre_master_secret = "D06F9C19BFF49B1E91E4EFE97345D0894E6C2E6C34A165B24540E2970875D6412AA6515871B389B4C199BB8389C71CED".as_bytes();
-            let hello_random     = "162B81EDFBEAE4F25240320B87E7651C865564191DD782DB0B9ECA275FBA1BB95A1DA3DF436D68DA86C5E7B4B4A36E46B977C61767983A31BE270D74517BD0F6".as_bytes();
-            let master_secret    = "EB38B8D89B98B1C266DE44BB3CA14E83C32F009F9955B1D994E61D3C51EE876090B4EF89CC7AF42F46E72201BFCC7977".as_bytes();
-            let mut label = "master secret".as_bytes();
+    fn test_hmac_variants() {
+        let test_cases = [
+            (WCShaHmac::Sha256, 32),
+            (WCShaHmac::Sha384, 48),
+        ];
 
-            let mut pms: [u8; 48] = mem::zeroed();
-            let mut seed: [u8; 64] = mem::zeroed();
-            let mut ms: [u8; 48] = mem::zeroed();
-            let mut result: [u8; 48] = mem::zeroed();
+        for (variant, expected_size) in test_cases {
+            let hmac = variant;
+            let key = "this is my key".as_bytes();
+            let hash = hmac.with_key(key);
 
-            let pre_master_secret_len: word32 = pre_master_secret.len() as word32;
-            let mut pms_sz: word32 = pms.len() as word32;
-            let mut seed_sz: word32 = seed.len() as word32;
-            let mut ms_sz: word32 = ms.len() as word32;
-            let mut ret;
+            let tag1 = hash.sign_concat(
+                &[],
+                &[
+                    "fake it".as_bytes(),
+                    "till you".as_bytes(),
+                    "make".as_bytes(),
+                    "it".as_bytes(),
+                ],
+                &[],
+            );
 
-            ret = Base16_Decode(
-                pre_master_secret.as_ptr(),
-                pre_master_secret_len, 
-                pms.as_mut_ptr(), 
-                &mut pms_sz as *mut u32);
-            if ret != 0 {
-                panic!("failed while calling Base16_Decode, with ret value: {}", ret);
-            }
+            let tag2 = hash.sign_concat(
+                &[],
+                &[
+                    "fake it".as_bytes(),
+                    "till you".as_bytes(),
+                    "make".as_bytes(),
+                    "it".as_bytes(),
+                ],
+                &[],
+            );
 
-            ret = Base16_Decode(
-                hello_random.as_ptr(),
-                hello_random.len() as word32, 
-                seed.as_mut_ptr(), 
-                &mut seed_sz as *mut u32);
-            if ret != 0 {
-                panic!("failed while calling Base16_Decode, with ret value: {}", ret);
-            }
-
-            ret = Base16_Decode(
-                master_secret.as_ptr(),
-                master_secret.len() as word32, 
-                ms.as_mut_ptr(), 
-                &mut ms_sz as *mut u32);
-            if ret != 0 {
-                panic!("failed while calling Base16_Decode, with ret value: {}", ret);
-            }
-
-            wc_prf(
-                &mut result,
-                &mut pms,
-                &mut label,
-                &mut seed
-            ).unwrap();
-
-            assert_eq!(result, ms);
+            assert_eq!(tag1.as_ref(), tag2.as_ref());
+            assert_eq!(tag1.as_ref().len(), expected_size);
         }
     }
 }


### PR DESCRIPTION
Added a new HKDF and PRF implementation using HMAC for both SHA-256 and SHA-384 (with associated unit tests).
Consolidated SHA-256 and SHA-384 HMAC implementations into a single WCShaHmac enum, simplifying the code and removing redundant implementations.
**Note: Will rebase once https://github.com/wolfSSL/rustls-wolfcrypt-provider/pull/13 is merged.**