### PR TITLE
Various fixes reported from analyzer

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -56,6 +56,6 @@ jobs:
       - name: Run clippy
         run: |
           cd wolfcrypt-rs
-          cargo clippy -- -D warnings
+          cargo clippy -- -D warnings -A unnecessary-transmutes
           cd ../rustls-wolfcrypt-provider
           cargo clippy -- -D warnings

--- a/rustls-wolfcrypt-provider/Cargo.toml
+++ b/rustls-wolfcrypt-provider/Cargo.toml
@@ -31,6 +31,7 @@ anyhow = "1.0.95"
 num_cpus = "1.16.0"
 lazy_static = "1.5.0"
 hex-literal = "0.4.1"
+zeroize = { version = "1", default-features = false, features = ["alloc", "derive"] }
 
 
 [dev-dependencies]

--- a/rustls-wolfcrypt-provider/src/aead/aes128gcm.rs
+++ b/rustls-wolfcrypt-provider/src/aead/aes128gcm.rs
@@ -65,8 +65,8 @@ impl Tls12AeadAlgorithm for Aes128Gcm {
     ) -> Result<ConnectionTrafficSecrets, UnsupportedOperationError> {
         let mut iv_as_vec = vec![0u8; GCM_NONCE_LENGTH];
 
-        iv_as_vec.copy_from_slice(iv);
-        iv_as_vec.copy_from_slice(explicit);
+        iv_as_vec[..4].copy_from_slice(iv);
+        iv_as_vec[4..].copy_from_slice(explicit);
 
         Ok(ConnectionTrafficSecrets::Aes128Gcm {
             key,

--- a/rustls-wolfcrypt-provider/src/aead/aes128gcm.rs
+++ b/rustls-wolfcrypt-provider/src/aead/aes128gcm.rs
@@ -4,7 +4,6 @@ use alloc::boxed::Box;
 use alloc::vec;
 use core::mem;
 use foreign_types::ForeignType;
-use zeroize::Zeroizing;
 use rustls::crypto::cipher::{
     make_tls12_aad, make_tls13_aad, AeadKey, InboundOpaqueMessage, InboundPlainMessage, Iv,
     KeyBlockShape, MessageDecrypter, MessageEncrypter, Nonce, OutboundOpaqueMessage,
@@ -12,6 +11,7 @@ use rustls::crypto::cipher::{
     UnsupportedOperationError,
 };
 use rustls::{ConnectionTrafficSecrets, ContentType, ProtocolVersion};
+use zeroize::Zeroizing;
 
 use alloc::vec::Vec;
 use core::ptr;

--- a/rustls-wolfcrypt-provider/src/aead/aes128gcm.rs
+++ b/rustls-wolfcrypt-provider/src/aead/aes128gcm.rs
@@ -4,6 +4,7 @@ use alloc::boxed::Box;
 use alloc::vec;
 use core::mem;
 use foreign_types::ForeignType;
+use zeroize::Zeroizing;
 use rustls::crypto::cipher::{
     make_tls12_aad, make_tls13_aad, AeadKey, InboundOpaqueMessage, InboundPlainMessage, Iv,
     KeyBlockShape, MessageDecrypter, MessageEncrypter, Nonce, OutboundOpaqueMessage,
@@ -30,7 +31,7 @@ impl Tls12AeadAlgorithm for Aes128Gcm {
 
         Box::new(WCTls12Encrypter {
             iv: iv_as_array.into(),
-            key: key_as_slice.to_vec(),
+            key: Zeroizing::new(key_as_slice.to_vec()),
         })
     }
 
@@ -45,7 +46,7 @@ impl Tls12AeadAlgorithm for Aes128Gcm {
 
         Box::new(WCTls12Decrypter {
             implicit_iv: iv_implicit_as_array,
-            key: key_as_slice.to_vec(),
+            key: Zeroizing::new(key_as_slice.to_vec()),
         })
     }
 
@@ -80,12 +81,12 @@ impl Tls12AeadAlgorithm for Aes128Gcm {
 // We separate the structs for the implementation.
 pub struct WCTls12Encrypter {
     iv: Iv,
-    key: Vec<u8>,
+    key: Zeroizing<Vec<u8>>,
 }
 
 pub struct WCTls12Decrypter {
     implicit_iv: [u8; 4],
-    key: Vec<u8>,
+    key: Zeroizing<Vec<u8>>,
 }
 
 impl MessageEncrypter for WCTls12Encrypter {
@@ -237,14 +238,14 @@ impl MessageDecrypter for WCTls12Decrypter {
 impl Tls13AeadAlgorithm for Aes128Gcm {
     fn encrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn MessageEncrypter> {
         Box::new(WCTls13Cipher {
-            key: key.as_ref().into(),
+            key: Zeroizing::new(key.as_ref().into()),
             iv,
         })
     }
 
     fn decrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn MessageDecrypter> {
         Box::new(WCTls13Cipher {
-            key: key.as_ref().into(),
+            key: Zeroizing::new(key.as_ref().into()),
             iv,
         })
     }
@@ -263,7 +264,7 @@ impl Tls13AeadAlgorithm for Aes128Gcm {
 }
 
 pub struct WCTls13Cipher {
-    key: Vec<u8>,
+    key: Zeroizing<Vec<u8>>,
     iv: Iv,
 }
 

--- a/rustls-wolfcrypt-provider/src/aead/aes256gcm.rs
+++ b/rustls-wolfcrypt-provider/src/aead/aes256gcm.rs
@@ -4,7 +4,6 @@ use alloc::boxed::Box;
 use alloc::vec;
 use core::mem;
 use foreign_types::ForeignType;
-use zeroize::Zeroizing;
 use rustls::crypto::cipher::{
     make_tls12_aad, make_tls13_aad, AeadKey, InboundOpaqueMessage, InboundPlainMessage, Iv,
     KeyBlockShape, MessageDecrypter, MessageEncrypter, Nonce, OutboundOpaqueMessage,
@@ -12,6 +11,7 @@ use rustls::crypto::cipher::{
     UnsupportedOperationError,
 };
 use rustls::{ConnectionTrafficSecrets, ContentType, ProtocolVersion};
+use zeroize::Zeroizing;
 
 use alloc::vec::Vec;
 use core::ptr;

--- a/rustls-wolfcrypt-provider/src/aead/aes256gcm.rs
+++ b/rustls-wolfcrypt-provider/src/aead/aes256gcm.rs
@@ -4,6 +4,7 @@ use alloc::boxed::Box;
 use alloc::vec;
 use core::mem;
 use foreign_types::ForeignType;
+use zeroize::Zeroizing;
 use rustls::crypto::cipher::{
     make_tls12_aad, make_tls13_aad, AeadKey, InboundOpaqueMessage, InboundPlainMessage, Iv,
     KeyBlockShape, MessageDecrypter, MessageEncrypter, Nonce, OutboundOpaqueMessage,
@@ -30,7 +31,7 @@ impl Tls12AeadAlgorithm for Aes256Gcm {
 
         Box::new(WCTls12Encrypter {
             iv: iv_as_array.into(),
-            key: key_as_slice.to_vec(),
+            key: Zeroizing::new(key_as_slice.to_vec()),
         })
     }
 
@@ -45,7 +46,7 @@ impl Tls12AeadAlgorithm for Aes256Gcm {
 
         Box::new(WCTls12Decrypter {
             implicit_iv: iv_implicit_as_array,
-            key: key_as_slice.to_vec(),
+            key: Zeroizing::new(key_as_slice.to_vec()),
         })
     }
 
@@ -80,12 +81,12 @@ impl Tls12AeadAlgorithm for Aes256Gcm {
 // We separate the structs for the implementation.
 pub struct WCTls12Encrypter {
     iv: Iv,
-    key: Vec<u8>,
+    key: Zeroizing<Vec<u8>>,
 }
 
 pub struct WCTls12Decrypter {
     implicit_iv: [u8; 4],
-    key: Vec<u8>,
+    key: Zeroizing<Vec<u8>>,
 }
 
 impl MessageEncrypter for WCTls12Encrypter {
@@ -237,14 +238,14 @@ impl MessageDecrypter for WCTls12Decrypter {
 impl Tls13AeadAlgorithm for Aes256Gcm {
     fn encrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn MessageEncrypter> {
         Box::new(WCTls13Cipher {
-            key: key.as_ref().into(),
+            key: Zeroizing::new(key.as_ref().into()),
             iv,
         })
     }
 
     fn decrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn MessageDecrypter> {
         Box::new(WCTls13Cipher {
-            key: key.as_ref().into(),
+            key: Zeroizing::new(key.as_ref().into()),
             iv,
         })
     }
@@ -263,7 +264,7 @@ impl Tls13AeadAlgorithm for Aes256Gcm {
 }
 
 pub struct WCTls13Cipher {
-    key: Vec<u8>,
+    key: Zeroizing<Vec<u8>>,
     iv: Iv,
 }
 

--- a/rustls-wolfcrypt-provider/src/aead/aes256gcm.rs
+++ b/rustls-wolfcrypt-provider/src/aead/aes256gcm.rs
@@ -65,8 +65,8 @@ impl Tls12AeadAlgorithm for Aes256Gcm {
     ) -> Result<ConnectionTrafficSecrets, UnsupportedOperationError> {
         let mut iv_as_vec = vec![0u8; GCM_NONCE_LENGTH];
 
-        iv_as_vec.copy_from_slice(iv);
-        iv_as_vec.copy_from_slice(explicit);
+        iv_as_vec[..4].copy_from_slice(iv);
+        iv_as_vec[4..].copy_from_slice(explicit);
 
         Ok(ConnectionTrafficSecrets::Aes256Gcm {
             key,

--- a/rustls-wolfcrypt-provider/src/aead/chacha20.rs
+++ b/rustls-wolfcrypt-provider/src/aead/chacha20.rs
@@ -13,6 +13,7 @@ use rustls::{ConnectionTrafficSecrets, ContentType, ProtocolVersion};
 use wolfcrypt_rs::*;
 
 use crate::error::check_if_zero;
+use zeroize::{Zeroizing};
 
 const CHACHAPOLY1305_OVERHEAD: usize = 16;
 
@@ -20,7 +21,7 @@ pub struct Chacha20Poly1305;
 
 impl Tls12AeadAlgorithm for Chacha20Poly1305 {
     fn encrypter(&self, key: AeadKey, iv: &[u8], _: &[u8]) -> Box<dyn MessageEncrypter> {
-        let mut key_as_vec = vec![0u8; 32];
+        let mut key_as_vec = Zeroizing::new(vec![0u8; 32]);
         key_as_vec.copy_from_slice(key.as_ref());
 
         Box::new(WCTls12Cipher {
@@ -30,7 +31,7 @@ impl Tls12AeadAlgorithm for Chacha20Poly1305 {
     }
 
     fn decrypter(&self, key: AeadKey, iv: &[u8]) -> Box<dyn MessageDecrypter> {
-        let mut key_as_vec = vec![0u8; 32];
+        let mut key_as_vec = Zeroizing::new(vec![0u8; 32]);
         key_as_vec.copy_from_slice(key.as_ref());
 
         Box::new(WCTls12Cipher {
@@ -63,7 +64,7 @@ impl Tls12AeadAlgorithm for Chacha20Poly1305 {
 }
 
 pub struct WCTls12Cipher {
-    key: Vec<u8>,
+    key: Zeroizing<Vec<u8>>,
     iv: Iv,
 }
 
@@ -175,7 +176,7 @@ impl MessageDecrypter for WCTls12Cipher {
 
 impl Tls13AeadAlgorithm for Chacha20Poly1305 {
     fn encrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn MessageEncrypter> {
-        let mut key_as_array = [0u8; 32];
+        let mut key_as_array = Zeroizing::new([0u8; 32]);
         key_as_array[..32].copy_from_slice(key.as_ref());
 
         Box::new(WCTls13Cipher {
@@ -185,7 +186,7 @@ impl Tls13AeadAlgorithm for Chacha20Poly1305 {
     }
 
     fn decrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn MessageDecrypter> {
-        let mut key_as_array = [0u8; 32];
+        let mut key_as_array = Zeroizing::new([0u8; 32]);
         key_as_array[..32].copy_from_slice(key.as_ref());
 
         Box::new(WCTls13Cipher {
@@ -208,7 +209,7 @@ impl Tls13AeadAlgorithm for Chacha20Poly1305 {
 }
 
 pub struct WCTls13Cipher {
-    key: [u8; 32],
+    key: Zeroizing<[u8; 32]>,
     iv: Iv,
 }
 

--- a/rustls-wolfcrypt-provider/src/aead/chacha20.rs
+++ b/rustls-wolfcrypt-provider/src/aead/chacha20.rs
@@ -13,7 +13,7 @@ use rustls::{ConnectionTrafficSecrets, ContentType, ProtocolVersion};
 use wolfcrypt_rs::*;
 
 use crate::error::check_if_zero;
-use zeroize::{Zeroizing};
+use zeroize::Zeroizing;
 
 const CHACHAPOLY1305_OVERHEAD: usize = 16;
 

--- a/rustls-wolfcrypt-provider/src/hash/sha256.rs
+++ b/rustls-wolfcrypt-provider/src/hash/sha256.rs
@@ -91,13 +91,21 @@ impl hash::Context for WCSha256Context {
 unsafe impl Sync for WCHasher256 {}
 unsafe impl Send for WCHasher256 {}
 impl Clone for WCHasher256 {
-    // Clone implementation.
-    // Returns a copy of the WCHasher256 struct.
     fn clone(&self) -> WCHasher256 {
-        WCHasher256 {
-            sha256_c_type: self.sha256_c_type,
+        let mut new_hasher = WCHasher256 {
+            sha256_c_type: unsafe { mem::zeroed() },
             hash: self.hash,
-        }
+        };
+        let ret = unsafe { wc_InitSha256(&mut new_hasher.sha256_c_type) };
+        check_if_zero(ret).unwrap();
+        let ret = unsafe {
+            wc_Sha256Copy(
+                &self.sha256_c_type as *const wc_Sha256 as *mut wc_Sha256,
+                &mut new_hasher.sha256_c_type,
+            )
+        };
+        check_if_zero(ret).unwrap();
+        new_hasher
     }
 }
 

--- a/rustls-wolfcrypt-provider/src/hash/sha384.rs
+++ b/rustls-wolfcrypt-provider/src/hash/sha384.rs
@@ -109,12 +109,20 @@ mod tests {
 unsafe impl Sync for WCHasher384 {}
 unsafe impl Send for WCHasher384 {}
 impl Clone for WCHasher384 {
-    // Clone implementation.
-    // Returns a copy of the WCHasher256 struct.
     fn clone(&self) -> WCHasher384 {
-        WCHasher384 {
-            sha384_c_type: self.sha384_c_type,
+        let mut new_hasher = WCHasher384 {
+            sha384_c_type: unsafe { mem::zeroed() },
             hash: self.hash,
-        }
+        };
+        let ret = unsafe { wc_InitSha384(&mut new_hasher.sha384_c_type) };
+        check_if_zero(ret).unwrap();
+        let ret = unsafe {
+            wc_Sha384Copy(
+                &self.sha384_c_type as *const wc_Sha384 as *mut wc_Sha384,
+                &mut new_hasher.sha384_c_type,
+            )
+        };
+        check_if_zero(ret).unwrap();
+        new_hasher
     }
 }

--- a/rustls-wolfcrypt-provider/src/hkdf.rs
+++ b/rustls-wolfcrypt-provider/src/hkdf.rs
@@ -7,6 +7,7 @@ use wolfcrypt_rs::*;
 
 use crate::error::check_if_zero;
 use crate::hmac::WCShaHmac;
+use zeroize::Zeroizing;
 
 pub struct WCHkdfUsingHmac(pub WCShaHmac);
 
@@ -43,7 +44,7 @@ impl RustlsHkdf for WCHkdfUsingHmac {
         check_if_zero(ret).unwrap();
 
         Box::new(WolfHkdfExpander::new(
-            extracted_key,
+            Zeroizing::new(extracted_key),
             self.0.hash_type().try_into().unwrap(),
             self.0.hash_len(),
         ))
@@ -54,7 +55,7 @@ impl RustlsHkdf for WCHkdfUsingHmac {
         okm: &rustls::crypto::tls13::OkmBlock,
     ) -> Box<dyn rustls::crypto::tls13::HkdfExpander> {
         Box::new(WolfHkdfExpander {
-            extracted_key: okm.as_ref().to_vec(),
+            extracted_key: Zeroizing::new(okm.as_ref().to_vec()),
             hash_type: self.0.hash_type().try_into().unwrap(),
             hash_len: self.0.hash_len(),
         })
@@ -92,13 +93,13 @@ impl RustlsHkdf for WCHkdfUsingHmac {
 
 /// Expander implementation that holds the extracted key material from HKDF extract phase
 struct WolfHkdfExpander {
-    extracted_key: Vec<u8>, // The pseudorandom key (PRK) output from HKDF-Extract
-    hash_type: i32,         // The wolfSSL hash algorithm identifier
-    hash_len: usize,        // Length of the hash function output
+    extracted_key: Zeroizing<Vec<u8>>, // The pseudorandom key (PRK) output from HKDF-Extract
+    hash_type: i32,                     // The wolfSSL hash algorithm identifier
+    hash_len: usize,                    // Length of the hash function output
 }
 
 impl WolfHkdfExpander {
-    fn new(extracted_key: Vec<u8>, hash_type: i32, hash_len: usize) -> Self {
+    fn new(extracted_key: Zeroizing<Vec<u8>>, hash_type: i32, hash_len: usize) -> Self {
         Self {
             extracted_key,
             hash_type,

--- a/rustls-wolfcrypt-provider/src/hkdf.rs
+++ b/rustls-wolfcrypt-provider/src/hkdf.rs
@@ -94,8 +94,8 @@ impl RustlsHkdf for WCHkdfUsingHmac {
 /// Expander implementation that holds the extracted key material from HKDF extract phase
 struct WolfHkdfExpander {
     extracted_key: Zeroizing<Vec<u8>>, // The pseudorandom key (PRK) output from HKDF-Extract
-    hash_type: i32,                     // The wolfSSL hash algorithm identifier
-    hash_len: usize,                    // Length of the hash function output
+    hash_type: i32,                    // The wolfSSL hash algorithm identifier
+    hash_len: usize,                   // Length of the hash function output
 }
 
 impl WolfHkdfExpander {

--- a/rustls-wolfcrypt-provider/src/hkdf.rs
+++ b/rustls-wolfcrypt-provider/src/hkdf.rs
@@ -85,7 +85,6 @@ impl RustlsHkdf for WCHkdfUsingHmac {
         check_if_zero(ret).unwrap();
 
         unsafe { wc_HmacFree(&mut hmac_ctx) };
-        check_if_zero(ret).unwrap();
 
         rustls::crypto::hmac::Tag::new(&hmac)
     }

--- a/rustls-wolfcrypt-provider/src/hkdf.rs
+++ b/rustls-wolfcrypt-provider/src/hkdf.rs
@@ -120,7 +120,7 @@ impl tls13::HkdfExpander for WolfHkdfExpander {
             return Err(tls13::OutputLengthError);
         }
 
-        unsafe {
+        let ret = unsafe {
             wc_HKDF_Expand(
                 self.hash_type,
                 self.extracted_key.as_ptr(),
@@ -129,8 +129,9 @@ impl tls13::HkdfExpander for WolfHkdfExpander {
                 info_concat.len() as u32,
                 output.as_mut_ptr(),
                 output.len() as u32,
-            );
-        }
+            )
+        };
+        check_if_zero(ret).map_err(|_| tls13::OutputLengthError)?;
 
         Ok(())
     }

--- a/rustls-wolfcrypt-provider/src/hmac/mod.rs
+++ b/rustls-wolfcrypt-provider/src/hmac/mod.rs
@@ -1,7 +1,6 @@
-use crate::{error::check_if_zero, types::*};
+use crate::error::check_if_zero;
 use alloc::{boxed::Box, vec, vec::Vec};
 use core::mem;
-use foreign_types::ForeignType;
 use rustls::crypto;
 use wolfcrypt_rs::*;
 
@@ -85,32 +84,35 @@ impl crypto::hmac::Key for WCHmacKey {
 }
 
 impl WCHmacKey {
-    fn hmac_init(&self) -> HmacObject {
-        let mut hmac_c_type: Hmac = unsafe { mem::zeroed() };
-        let hmac_object = unsafe { HmacObject::from_ptr(&mut hmac_c_type) };
+    fn hmac_init(&self) -> *mut Hmac {
+        let hmac_ptr = Box::into_raw(Box::new(unsafe { mem::zeroed::<Hmac>() }));
 
         let ret = unsafe {
             wc_HmacSetKey(
-                hmac_object.as_ptr(),
+                hmac_ptr,
                 self.variant.algorithm(),
                 self.key.as_ptr(),
                 self.key.len() as word32,
             )
         };
         check_if_zero(ret).unwrap();
-        hmac_object
+        hmac_ptr
     }
 
-    fn hmac_update(&self, hmac_object: HmacObject, input: &[u8]) {
+    fn hmac_update(&self, hmac_ptr: *mut Hmac, input: &[u8]) {
         let ret =
-            unsafe { wc_HmacUpdate(hmac_object.as_ptr(), input.as_ptr(), input.len() as word32) };
+            unsafe { wc_HmacUpdate(hmac_ptr, input.as_ptr(), input.len() as word32) };
         check_if_zero(ret).unwrap();
     }
 
-    fn hmac_final(&self, hmac_object: HmacObject) -> Vec<u8> {
+    fn hmac_final(&self, hmac_ptr: *mut Hmac) -> Vec<u8> {
         let mut digest = vec![0u8; self.variant.digest_size()];
-        let ret = unsafe { wc_HmacFinal(hmac_object.as_ptr(), digest.as_mut_ptr()) };
+        let ret = unsafe { wc_HmacFinal(hmac_ptr, digest.as_mut_ptr()) };
         check_if_zero(ret).unwrap();
+
+        // Free the heap-allocated Hmac struct.
+        unsafe { drop(Box::from_raw(hmac_ptr)); }
+
         digest
     }
 }

--- a/rustls-wolfcrypt-provider/src/hmac/mod.rs
+++ b/rustls-wolfcrypt-provider/src/hmac/mod.rs
@@ -2,6 +2,7 @@ use crate::error::check_if_zero;
 use alloc::{boxed::Box, vec, vec::Vec};
 use core::mem;
 use rustls::crypto;
+use zeroize::Zeroizing;
 use wolfcrypt_rs::*;
 
 #[derive(Clone, Copy)]
@@ -51,7 +52,7 @@ impl WCShaHmac {
 impl crypto::hmac::Hmac for WCShaHmac {
     fn with_key(&self, key: &[u8]) -> Box<dyn crypto::hmac::Key> {
         Box::new(WCHmacKey {
-            key: key.to_vec(),
+            key: Zeroizing::new(key.to_vec()),
             variant: *self,
         })
     }
@@ -62,7 +63,7 @@ impl crypto::hmac::Hmac for WCShaHmac {
 }
 
 struct WCHmacKey {
-    key: Vec<u8>,
+    key: Zeroizing<Vec<u8>>,
     variant: WCShaHmac,
 }
 

--- a/rustls-wolfcrypt-provider/src/hmac/mod.rs
+++ b/rustls-wolfcrypt-provider/src/hmac/mod.rs
@@ -2,8 +2,8 @@ use crate::error::check_if_zero;
 use alloc::{boxed::Box, vec, vec::Vec};
 use core::mem;
 use rustls::crypto;
-use zeroize::Zeroizing;
 use wolfcrypt_rs::*;
+use zeroize::Zeroizing;
 
 #[derive(Clone, Copy)]
 pub enum WCShaHmac {
@@ -101,8 +101,7 @@ impl WCHmacKey {
     }
 
     fn hmac_update(&self, hmac_ptr: *mut Hmac, input: &[u8]) {
-        let ret =
-            unsafe { wc_HmacUpdate(hmac_ptr, input.as_ptr(), input.len() as word32) };
+        let ret = unsafe { wc_HmacUpdate(hmac_ptr, input.as_ptr(), input.len() as word32) };
         check_if_zero(ret).unwrap();
     }
 
@@ -112,7 +111,9 @@ impl WCHmacKey {
         check_if_zero(ret).unwrap();
 
         // Free the heap-allocated Hmac struct.
-        unsafe { drop(Box::from_raw(hmac_ptr)); }
+        unsafe {
+            drop(Box::from_raw(hmac_ptr));
+        }
 
         digest
     }

--- a/rustls-wolfcrypt-provider/src/hmac/sha256hmac.rs
+++ b/rustls-wolfcrypt-provider/src/hmac/sha256hmac.rs
@@ -1,8 +1,7 @@
-use crate::{error::check_if_zero, types::*};
+use crate::error::check_if_zero;
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::mem;
-use foreign_types::ForeignType;
 use rustls::crypto;
 
 use wolfcrypt_rs::*;
@@ -47,15 +46,14 @@ impl crypto::hmac::Key for WCHmac256Key {
 }
 
 impl WCHmac256Key {
-    fn hmac_init(&self) -> HmacObject {
-        let mut hmac_c_type: Hmac = unsafe { mem::zeroed() };
-        let hmac_object = unsafe { HmacObject::from_ptr(&mut hmac_c_type) };
+    fn hmac_init(&self) -> *mut Hmac {
+        let hmac_ptr = Box::into_raw(Box::new(unsafe { mem::zeroed::<Hmac>() }));
 
         // This function initializes an Hmac object, setting
         // its encryption type, key and HMAC length.
         let ret = unsafe {
             wc_HmacSetKey(
-                hmac_object.as_ptr(),
+                hmac_ptr,
                 WC_SHA256.try_into().unwrap(),
                 self.key.as_ptr(),
                 self.key.len() as word32,
@@ -63,26 +61,25 @@ impl WCHmac256Key {
         };
         check_if_zero(ret).unwrap();
 
-        hmac_object
+        hmac_ptr
     }
 
-    fn hmac_update(&self, hmac_object: HmacObject, input: &[u8]) {
-        // This function updates the message to authenticate using HMAC. It should be called after the
-        // Hmac object has been initialized with wc_HmacSetKey. This function may be called multiple
-        // times to update the message to hash. After calling wc_HmacUpdate as desired, one should call
-        // wc_HmacFinal to obtain the final authenticated message tag.
+    fn hmac_update(&self, hmac_ptr: *mut Hmac, input: &[u8]) {
         let ret =
-            unsafe { wc_HmacUpdate(hmac_object.as_ptr(), input.as_ptr(), input.len() as word32) };
+            unsafe { wc_HmacUpdate(hmac_ptr, input.as_ptr(), input.len() as word32) };
 
         check_if_zero(ret).unwrap();
     }
 
-    fn hmac_final(&self, hmac_object: HmacObject) -> [u8; WC_SHA256_DIGEST_SIZE as usize] {
+    fn hmac_final(&self, hmac_ptr: *mut Hmac) -> [u8; WC_SHA256_DIGEST_SIZE as usize] {
         let mut digest: [u8; WC_SHA256_DIGEST_SIZE as usize] = [0; WC_SHA256_DIGEST_SIZE as usize];
 
         // This function computes the final hash of an Hmac object's message.
-        let ret = unsafe { wc_HmacFinal(hmac_object.as_ptr(), digest.as_mut_ptr()) };
+        let ret = unsafe { wc_HmacFinal(hmac_ptr, digest.as_mut_ptr()) };
         check_if_zero(ret).unwrap();
+
+        // Free the heap-allocated Hmac struct.
+        unsafe { drop(Box::from_raw(hmac_ptr)); }
 
         digest
     }

--- a/rustls-wolfcrypt-provider/src/hmac/sha256hmac.rs
+++ b/rustls-wolfcrypt-provider/src/hmac/sha256hmac.rs
@@ -3,6 +3,7 @@ use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::mem;
 use rustls::crypto;
+use zeroize::Zeroizing;
 
 use wolfcrypt_rs::*;
 
@@ -10,7 +11,7 @@ pub struct WCSha256Hmac;
 
 impl crypto::hmac::Hmac for WCSha256Hmac {
     fn with_key(&self, key: &[u8]) -> Box<dyn crypto::hmac::Key> {
-        Box::new(WCHmac256Key { key: key.to_vec() })
+        Box::new(WCHmac256Key { key: Zeroizing::new(key.to_vec()) })
     }
 
     fn hash_output_len(&self) -> usize {
@@ -19,7 +20,7 @@ impl crypto::hmac::Hmac for WCSha256Hmac {
 }
 
 struct WCHmac256Key {
-    key: Vec<u8>,
+    key: Zeroizing<Vec<u8>>,
 }
 
 impl crypto::hmac::Key for WCHmac256Key {

--- a/rustls-wolfcrypt-provider/src/hmac/sha384hmac.rs
+++ b/rustls-wolfcrypt-provider/src/hmac/sha384hmac.rs
@@ -1,8 +1,7 @@
-use crate::{error::check_if_zero, types::*};
+use crate::error::check_if_zero;
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::mem;
-use foreign_types::ForeignType;
 use rustls::crypto;
 use wolfcrypt_rs::*;
 
@@ -46,15 +45,14 @@ impl crypto::hmac::Key for WCHmac384Key {
 }
 
 impl WCHmac384Key {
-    fn hmac_init(&self) -> HmacObject {
-        let mut hmac_c_type: wolfcrypt_rs::Hmac = unsafe { mem::zeroed() };
-        let hmac_object = unsafe { HmacObject::from_ptr(&mut hmac_c_type) };
+    fn hmac_init(&self) -> *mut wolfcrypt_rs::Hmac {
+        let hmac_ptr = Box::into_raw(Box::new(unsafe { mem::zeroed::<wolfcrypt_rs::Hmac>() }));
 
         // This function initializes an Hmac object, setting
         // its encryption type, key and HMAC length.
         let ret = unsafe {
             wc_HmacSetKey(
-                hmac_object.as_ptr(),
+                hmac_ptr,
                 WC_SHA384.try_into().unwrap(),
                 self.key.as_ptr(),
                 self.key.len() as word32,
@@ -62,28 +60,27 @@ impl WCHmac384Key {
         };
         check_if_zero(ret).unwrap();
 
-        hmac_object
+        hmac_ptr
     }
 
-    fn hmac_update(&self, hmac_object: HmacObject, input: &[u8]) {
-        // This function updates the message to authenticate using HMAC. It should be called after the
-        // Hmac object has been initialized with wc_HmacSetKey. This function may be called multiple
-        // times to update the message to hash. After calling wc_HmacUpdate as desired, one should call
-        // wc_HmacFinal to obtain the final authenticated message tag.
+    fn hmac_update(&self, hmac_ptr: *mut wolfcrypt_rs::Hmac, input: &[u8]) {
         let ret =
-            unsafe { wc_HmacUpdate(hmac_object.as_ptr(), input.as_ptr(), input.len() as word32) };
+            unsafe { wc_HmacUpdate(hmac_ptr, input.as_ptr(), input.len() as word32) };
 
         check_if_zero(ret).unwrap();
     }
 
-    fn hmac_final(&self, hmac_object: HmacObject) -> [u8; WC_SHA384_DIGEST_SIZE as usize] {
+    fn hmac_final(&self, hmac_ptr: *mut wolfcrypt_rs::Hmac) -> [u8; WC_SHA384_DIGEST_SIZE as usize] {
         let mut digest: [u8; WC_SHA384_DIGEST_SIZE as usize] =
             [0; WC_SHA384_DIGEST_SIZE as usize];
 
         // This function computes the final hash of an Hmac object's message.
-        let ret = unsafe { wc_HmacFinal(hmac_object.as_ptr(), digest.as_mut_ptr()) };
+        let ret = unsafe { wc_HmacFinal(hmac_ptr, digest.as_mut_ptr()) };
 
         check_if_zero(ret).unwrap();
+
+        // Free the heap-allocated Hmac struct.
+        unsafe { drop(Box::from_raw(hmac_ptr)); }
 
         digest
     }

--- a/rustls-wolfcrypt-provider/src/hmac/sha384hmac.rs
+++ b/rustls-wolfcrypt-provider/src/hmac/sha384hmac.rs
@@ -78,7 +78,7 @@ impl WCHmac384Key {
 
     fn hmac_final(&self, hmac_object: HmacObject) -> [u8; WC_SHA384_DIGEST_SIZE as usize] {
         let mut digest: [u8; WC_SHA384_DIGEST_SIZE as usize] =
-            [0; WC_SHA3_384_DIGEST_SIZE as usize];
+            [0; WC_SHA384_DIGEST_SIZE as usize];
 
         // This function computes the final hash of an Hmac object's message.
         let ret = unsafe { wc_HmacFinal(hmac_object.as_ptr(), digest.as_mut_ptr()) };

--- a/rustls-wolfcrypt-provider/src/hmac/sha384hmac.rs
+++ b/rustls-wolfcrypt-provider/src/hmac/sha384hmac.rs
@@ -3,13 +3,14 @@ use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::mem;
 use rustls::crypto;
+use zeroize::Zeroizing;
 use wolfcrypt_rs::*;
 
 pub struct WCSha384Hmac;
 
 impl crypto::hmac::Hmac for WCSha384Hmac {
     fn with_key(&self, key: &[u8]) -> Box<dyn crypto::hmac::Key> {
-        Box::new(WCHmac384Key { key: key.to_vec() })
+        Box::new(WCHmac384Key { key: Zeroizing::new(key.to_vec()) })
     }
 
     fn hash_output_len(&self) -> usize {
@@ -18,7 +19,7 @@ impl crypto::hmac::Hmac for WCSha384Hmac {
 }
 
 struct WCHmac384Key {
-    key: Vec<u8>,
+    key: Zeroizing<Vec<u8>>,
 }
 
 impl crypto::hmac::Key for WCHmac384Key {

--- a/rustls-wolfcrypt-provider/src/kx/sec256r1.rs
+++ b/rustls-wolfcrypt-provider/src/kx/sec256r1.rs
@@ -86,7 +86,9 @@ impl KeyExchangeSecP256r1 {
 
     pub fn derive_shared_secret(&self, peer_pub_key: &[u8]) -> Result<Box<[u8]>, rustls::Error> {
         if peer_pub_key.len() != 65 {
-            return Err(rustls::Error::General("Invalid peer public key length".into()));
+            return Err(rustls::Error::General(
+                "Invalid peer public key length".into(),
+            ));
         }
 
         let mut priv_key: ecc_key = unsafe { mem::zeroed() };

--- a/rustls-wolfcrypt-provider/src/kx/sec256r1.rs
+++ b/rustls-wolfcrypt-provider/src/kx/sec256r1.rs
@@ -83,7 +83,11 @@ impl KeyExchangeSecP256r1 {
         }
     }
 
-    pub fn derive_shared_secret(&self, peer_pub_key: &[u8]) -> Box<[u8]> {
+    pub fn derive_shared_secret(&self, peer_pub_key: &[u8]) -> Result<Box<[u8]>, rustls::Error> {
+        if peer_pub_key.len() != 65 {
+            return Err(rustls::Error::General("Invalid peer public key length".into()));
+        }
+
         let mut priv_key: ecc_key = unsafe { mem::zeroed() };
         let priv_key_object = ECCKeyObject::new(&mut priv_key);
         let mut pub_key: ecc_key = unsafe { mem::zeroed() };
@@ -139,7 +143,7 @@ impl KeyExchangeSecP256r1 {
         };
         check_if_zero(ret).unwrap();
 
-        Box::new(out)
+        Ok(Box::new(out))
     }
 }
 
@@ -148,7 +152,7 @@ impl rustls::crypto::ActiveKeyExchange for KeyExchangeSecP256r1 {
         self: Box<Self>,
         peer_pub_key: &[u8],
     ) -> Result<rustls::crypto::SharedSecret, rustls::Error> {
-        let secret = self.derive_shared_secret(peer_pub_key);
+        let secret = self.derive_shared_secret(peer_pub_key)?;
         Ok(rustls::crypto::SharedSecret::from(&*secret))
     }
 
@@ -172,8 +176,8 @@ mod tests {
         let bob = Box::new(KeyExchangeSecP256r1::use_secp256r1());
 
         assert_eq!(
-            alice.derive_shared_secret(bob.pub_key()),
-            bob.derive_shared_secret(alice.pub_key()),
+            alice.derive_shared_secret(bob.pub_key()).unwrap(),
+            bob.derive_shared_secret(alice.pub_key()).unwrap(),
         )
     }
 }

--- a/rustls-wolfcrypt-provider/src/kx/sec256r1.rs
+++ b/rustls-wolfcrypt-provider/src/kx/sec256r1.rs
@@ -4,9 +4,10 @@ use core::mem;
 use core::ptr;
 use foreign_types::ForeignType;
 use wolfcrypt_rs::*;
+use zeroize::Zeroizing;
 
 pub struct KeyExchangeSecP256r1 {
-    priv_key_bytes: Box<[u8]>,
+    priv_key_bytes: Zeroizing<Box<[u8]>>,
     pub_key_bytes: Box<[u8]>,
 }
 
@@ -78,7 +79,7 @@ impl KeyExchangeSecP256r1 {
         pub_key_bytes[33..65].copy_from_slice(&pub_key_raw.qy);
 
         KeyExchangeSecP256r1 {
-            priv_key_bytes: Box::new(priv_key_raw),
+            priv_key_bytes: Zeroizing::new(Box::new(priv_key_raw)),
             pub_key_bytes: Box::new(pub_key_bytes),
         }
     }

--- a/rustls-wolfcrypt-provider/src/kx/sec384r1.rs
+++ b/rustls-wolfcrypt-provider/src/kx/sec384r1.rs
@@ -89,7 +89,9 @@ impl KeyExchangeSecP384r1 {
 
     pub fn derive_shared_secret(&self, peer_pub_key: &[u8]) -> Result<Box<[u8]>, rustls::Error> {
         if peer_pub_key.len() != 97 {
-            return Err(rustls::Error::General("Invalid peer public key length".into()));
+            return Err(rustls::Error::General(
+                "Invalid peer public key length".into(),
+            ));
         }
 
         let mut priv_key: ecc_key = unsafe { mem::zeroed() };

--- a/rustls-wolfcrypt-provider/src/kx/sec384r1.rs
+++ b/rustls-wolfcrypt-provider/src/kx/sec384r1.rs
@@ -5,9 +5,10 @@ use core::mem;
 use core::ptr;
 use foreign_types::ForeignType;
 use wolfcrypt_rs::*;
+use zeroize::Zeroizing;
 
 pub struct KeyExchangeSecP384r1 {
-    priv_key_bytes: Box<[u8]>,
+    priv_key_bytes: Zeroizing<Box<[u8]>>,
     pub_key_bytes: Box<[u8]>,
 }
 
@@ -81,7 +82,7 @@ impl KeyExchangeSecP384r1 {
         pub_key_bytes[49..97].copy_from_slice(&pub_key_raw.qy);
 
         KeyExchangeSecP384r1 {
-            priv_key_bytes: Box::new(priv_key_raw),
+            priv_key_bytes: Zeroizing::new(Box::new(priv_key_raw)),
             pub_key_bytes: Box::new(pub_key_bytes),
         }
     }

--- a/rustls-wolfcrypt-provider/src/kx/sec384r1.rs
+++ b/rustls-wolfcrypt-provider/src/kx/sec384r1.rs
@@ -86,7 +86,11 @@ impl KeyExchangeSecP384r1 {
         }
     }
 
-    pub fn derive_shared_secret(&self, peer_pub_key: &[u8]) -> Box<[u8]> {
+    pub fn derive_shared_secret(&self, peer_pub_key: &[u8]) -> Result<Box<[u8]>, rustls::Error> {
+        if peer_pub_key.len() != 97 {
+            return Err(rustls::Error::General("Invalid peer public key length".into()));
+        }
+
         let mut priv_key: ecc_key = unsafe { mem::zeroed() };
         let priv_key_object: ECCKeyObject = ECCKeyObject::new(&mut priv_key);
         let mut pub_key: ecc_key = unsafe { mem::zeroed() };
@@ -146,7 +150,7 @@ impl KeyExchangeSecP384r1 {
         };
         check_if_zero(ret).unwrap();
 
-        Box::new(out)
+        Ok(Box::new(out))
     }
 }
 
@@ -155,10 +159,7 @@ impl rustls::crypto::ActiveKeyExchange for KeyExchangeSecP384r1 {
         self: Box<Self>,
         peer_pub_key: &[u8],
     ) -> Result<rustls::crypto::SharedSecret, rustls::Error> {
-        // We derive the shared secret with our private key and
-        // the received public key.
-        let secret = self.derive_shared_secret(peer_pub_key);
-
+        let secret = self.derive_shared_secret(peer_pub_key)?;
         Ok(rustls::crypto::SharedSecret::from(&*secret))
     }
 
@@ -182,8 +183,8 @@ mod tests {
         let bob = Box::new(KeyExchangeSecP384r1::use_secp384r1());
 
         assert_eq!(
-            alice.derive_shared_secret(bob.pub_key().try_into().unwrap()),
-            bob.derive_shared_secret(alice.pub_key().try_into().unwrap()),
+            alice.derive_shared_secret(bob.pub_key()).unwrap(),
+            bob.derive_shared_secret(alice.pub_key()).unwrap(),
         )
     }
 }

--- a/rustls-wolfcrypt-provider/src/kx/sec521r1.rs
+++ b/rustls-wolfcrypt-provider/src/kx/sec521r1.rs
@@ -4,9 +4,10 @@ use core::mem;
 use core::ptr;
 use foreign_types::ForeignType;
 use wolfcrypt_rs::*;
+use zeroize::Zeroizing;
 
 pub struct KeyExchangeSecP521r1 {
-    priv_key_bytes: Box<[u8]>,
+    priv_key_bytes: Zeroizing<Box<[u8]>>,
     pub_key_bytes: Box<[u8]>,
 }
 
@@ -81,7 +82,7 @@ impl KeyExchangeSecP521r1 {
         pub_key_bytes[67..133].copy_from_slice(&pub_key_raw.qy);
 
         KeyExchangeSecP521r1 {
-            priv_key_bytes: Box::new(priv_key_raw),
+            priv_key_bytes: Zeroizing::new(Box::new(priv_key_raw)),
             pub_key_bytes: Box::new(pub_key_bytes),
         }
     }

--- a/rustls-wolfcrypt-provider/src/kx/sec521r1.rs
+++ b/rustls-wolfcrypt-provider/src/kx/sec521r1.rs
@@ -89,7 +89,9 @@ impl KeyExchangeSecP521r1 {
 
     pub fn derive_shared_secret(&self, peer_pub_key: &[u8]) -> Result<Box<[u8]>, rustls::Error> {
         if peer_pub_key.len() != 133 {
-            return Err(rustls::Error::General("Invalid peer public key length".into()));
+            return Err(rustls::Error::General(
+                "Invalid peer public key length".into(),
+            ));
         }
 
         let mut priv_key: ecc_key = unsafe { mem::zeroed() };

--- a/rustls-wolfcrypt-provider/src/kx/sec521r1.rs
+++ b/rustls-wolfcrypt-provider/src/kx/sec521r1.rs
@@ -86,7 +86,11 @@ impl KeyExchangeSecP521r1 {
         }
     }
 
-    pub fn derive_shared_secret(&self, peer_pub_key: &[u8]) -> Box<[u8]> {
+    pub fn derive_shared_secret(&self, peer_pub_key: &[u8]) -> Result<Box<[u8]>, rustls::Error> {
+        if peer_pub_key.len() != 133 {
+            return Err(rustls::Error::General("Invalid peer public key length".into()));
+        }
+
         let mut priv_key: ecc_key = unsafe { mem::zeroed() };
         let priv_key_object: ECCKeyObject = ECCKeyObject::new(&mut priv_key);
         let mut pub_key: ecc_key = unsafe { mem::zeroed() };
@@ -147,7 +151,7 @@ impl KeyExchangeSecP521r1 {
         };
         check_if_zero(ret).unwrap();
 
-        Box::new(out)
+        Ok(Box::new(out))
     }
 }
 
@@ -156,10 +160,7 @@ impl rustls::crypto::ActiveKeyExchange for KeyExchangeSecP521r1 {
         self: Box<Self>,
         peer_pub_key: &[u8],
     ) -> Result<rustls::crypto::SharedSecret, rustls::Error> {
-        // We derive the shared secret with our private key and
-        // the received public key.
-        let secret = self.derive_shared_secret(peer_pub_key);
-
+        let secret = self.derive_shared_secret(peer_pub_key)?;
         Ok(rustls::crypto::SharedSecret::from(&*secret))
     }
 
@@ -183,8 +184,8 @@ mod tests {
         let bob = Box::new(KeyExchangeSecP521r1::use_secp521r1());
 
         assert_eq!(
-            alice.derive_shared_secret(bob.pub_key().try_into().unwrap()),
-            bob.derive_shared_secret(alice.pub_key().try_into().unwrap()),
+            alice.derive_shared_secret(bob.pub_key()).unwrap(),
+            bob.derive_shared_secret(alice.pub_key()).unwrap(),
         )
     }
 }

--- a/rustls-wolfcrypt-provider/src/kx/x25519.rs
+++ b/rustls-wolfcrypt-provider/src/kx/x25519.rs
@@ -3,10 +3,11 @@ use alloc::boxed::Box;
 use core::mem;
 use foreign_types::ForeignType;
 use wolfcrypt_rs::*;
+use zeroize::Zeroizing;
 
 pub struct KeyExchangeX25519 {
     pub_key_bytes: Box<[u8]>,
-    priv_key_bytes: Box<[u8]>,
+    priv_key_bytes: Zeroizing<Box<[u8]>>,
 }
 
 impl KeyExchangeX25519 {
@@ -48,7 +49,7 @@ impl KeyExchangeX25519 {
 
         KeyExchangeX25519 {
             pub_key_bytes: Box::new(pub_key_raw),
-            priv_key_bytes: Box::new(priv_key_raw),
+            priv_key_bytes: Zeroizing::new(Box::new(priv_key_raw)),
         }
     }
 

--- a/rustls-wolfcrypt-provider/src/sign/ecdsa.rs
+++ b/rustls-wolfcrypt-provider/src/sign/ecdsa.rs
@@ -14,6 +14,7 @@ use rustls::sign::{Signer, SigningKey};
 use rustls::{SignatureAlgorithm, SignatureScheme};
 
 use wolfcrypt_rs::*;
+use zeroize::Zeroizing;
 
 /// A unified ECDSA signing key that supports P-256, P-384, P-521.
 /// Internally, we store the raw private key bytes plus
@@ -22,7 +23,7 @@ use wolfcrypt_rs::*;
 pub struct EcdsaSigningKey {
     /// Raw private key bytes exported from WolfSSL (`wc_ecc_export_private_only`)
     /// in big-endian format.
-    key: Arc<Vec<u8>>,
+    key: Arc<Zeroizing<Vec<u8>>>,
     /// The signature scheme to use (e.g. ECDSA_NISTP256_SHA256).
     scheme: SignatureScheme,
 }
@@ -89,7 +90,7 @@ impl TryFrom<&PrivateKeyDer<'_>> for EcdsaSigningKey {
             curve_id_to_scheme(key_size).map_err(|e| rustls::Error::General(e.to_string()))?;
 
         Ok(Self {
-            key: Arc::new(priv_key_bytes),
+            key: Arc::new(Zeroizing::new(priv_key_bytes)),
             scheme,
         })
     }

--- a/rustls-wolfcrypt-provider/src/sign/eddsa.rs
+++ b/rustls-wolfcrypt-provider/src/sign/eddsa.rs
@@ -153,9 +153,10 @@ impl Signer for Ed25519Signer {
             )
         };
         if ret < 0 {
-            return Err(rustls::Error::General(
-                format!("wc_ed25519_sign_msg failed: {}", ret),
-            ));
+            return Err(rustls::Error::General(format!(
+                "wc_ed25519_sign_msg failed: {}",
+                ret
+            )));
         }
 
         let mut sig_vec = sig.to_vec();

--- a/rustls-wolfcrypt-provider/src/sign/eddsa.rs
+++ b/rustls-wolfcrypt-provider/src/sign/eddsa.rs
@@ -8,6 +8,7 @@ use foreign_types::ForeignType;
 use rustls::pki_types::PrivateKeyDer;
 use rustls::sign::{Signer, SigningKey};
 use rustls::{SignatureAlgorithm, SignatureScheme};
+use alloc::format;
 
 use wolfcrypt_rs::*;
 
@@ -151,7 +152,9 @@ impl Signer for Ed25519Signer {
             )
         };
         if ret < 0 {
-            panic!("{}", ret);
+            return Err(rustls::Error::General(
+                    format!("wc_ed25519_sign_msg failed: {}", ret).into()
+            ));
         }
 
         let mut sig_vec = sig.to_vec();

--- a/rustls-wolfcrypt-provider/src/sign/eddsa.rs
+++ b/rustls-wolfcrypt-provider/src/sign/eddsa.rs
@@ -11,12 +11,13 @@ use rustls::{SignatureAlgorithm, SignatureScheme};
 use alloc::format;
 
 use wolfcrypt_rs::*;
+use zeroize::Zeroizing;
 
 const ALL_EDDSA_SCHEMES: &[SignatureScheme] = &[SignatureScheme::ED25519];
 
 #[derive(Clone, Debug)]
 pub struct Ed25519PrivateKey {
-    priv_key: Arc<Vec<u8>>,
+    priv_key: Arc<Zeroizing<Vec<u8>>>,
     pub_key: Arc<Vec<u8>>,
     algo: SignatureAlgorithm,
 }
@@ -78,7 +79,7 @@ impl TryFrom<&PrivateKeyDer<'_>> for Ed25519PrivateKey {
                     .map_err(|_| rustls::Error::General("FFI function failed".into()))?;
 
                 Ok(Self {
-                    priv_key: Arc::new(priv_key_raw.to_vec()),
+                    priv_key: Arc::new(Zeroizing::new(priv_key_raw.to_vec())),
                     pub_key: Arc::new(pub_key_raw.to_vec()),
                     algo: SignatureAlgorithm::ED25519,
                 })
@@ -113,7 +114,7 @@ impl SigningKey for Ed25519PrivateKey {
 
 #[derive(Clone, Debug)]
 pub struct Ed25519Signer {
-    priv_key: Arc<Vec<u8>>,
+    priv_key: Arc<Zeroizing<Vec<u8>>>,
     pub_key: Arc<Vec<u8>>,
     scheme: SignatureScheme,
 }

--- a/rustls-wolfcrypt-provider/src/sign/eddsa.rs
+++ b/rustls-wolfcrypt-provider/src/sign/eddsa.rs
@@ -154,7 +154,7 @@ impl Signer for Ed25519Signer {
         };
         if ret < 0 {
             return Err(rustls::Error::General(
-                format!("wc_ed25519_sign_msg failed: {}", ret).into(),
+                format!("wc_ed25519_sign_msg failed: {}", ret),
             ));
         }
 

--- a/rustls-wolfcrypt-provider/src/sign/eddsa.rs
+++ b/rustls-wolfcrypt-provider/src/sign/eddsa.rs
@@ -11,7 +11,7 @@ use rustls::{SignatureAlgorithm, SignatureScheme};
 
 use wolfcrypt_rs::*;
 
-const ALL_EDDSA_SCHEMES: &[SignatureScheme] = &[SignatureScheme::ED25519, SignatureScheme::ED448];
+const ALL_EDDSA_SCHEMES: &[SignatureScheme] = &[SignatureScheme::ED25519];
 
 #[derive(Clone, Debug)]
 pub struct Ed25519PrivateKey {

--- a/rustls-wolfcrypt-provider/src/sign/eddsa.rs
+++ b/rustls-wolfcrypt-provider/src/sign/eddsa.rs
@@ -1,6 +1,7 @@
 use crate::error::*;
 use crate::types::*;
 use alloc::boxed::Box;
+use alloc::format;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::mem;
@@ -8,7 +9,6 @@ use foreign_types::ForeignType;
 use rustls::pki_types::PrivateKeyDer;
 use rustls::sign::{Signer, SigningKey};
 use rustls::{SignatureAlgorithm, SignatureScheme};
-use alloc::format;
 
 use wolfcrypt_rs::*;
 use zeroize::Zeroizing;
@@ -154,7 +154,7 @@ impl Signer for Ed25519Signer {
         };
         if ret < 0 {
             return Err(rustls::Error::General(
-                    format!("wc_ed25519_sign_msg failed: {}", ret).into()
+                format!("wc_ed25519_sign_msg failed: {}", ret).into(),
             ));
         }
 

--- a/rustls-wolfcrypt-provider/src/sign/rsa.rs
+++ b/rustls-wolfcrypt-provider/src/sign/rsa.rs
@@ -31,15 +31,27 @@ const MGF1_SHA256: u32 = WC_MGF1SHA256;
 const MGF1_SHA384: u32 = WC_MGF1SHA384;
 const MGF1_SHA512: u32 = WC_MGF1SHA512;
 
+/// Owns a heap-allocated RsaKey along with the RsaKeyObject wrapper.
+/// The Box keeps the heap memory alive while RsaKeyObject holds the pointer.
+/// Fields are ordered so that rsa_key_object drops first (calling wc_FreeRsaKey
+/// to clean up wolfSSL internals), then _rsa_key_box drops to free the heap memory.
+#[derive(Debug)]
+struct OwnedRsaKey {
+    rsa_key_object: RsaKeyObject,
+    _rsa_key_box: Box<RsaKey>,
+}
+unsafe impl Send for OwnedRsaKey {}
+unsafe impl Sync for OwnedRsaKey {}
+
 #[derive(Clone, Debug)]
 pub struct RsaPrivateKey {
-    key: Arc<RsaKeyObject>,
+    key: Arc<OwnedRsaKey>,
     algo: SignatureAlgorithm,
 }
 
 impl RsaPrivateKey {
-    pub fn get_key(&self) -> Arc<RsaKeyObject> {
-        Arc::clone(&self.key)
+    pub fn get_rsa_key_object(&self) -> &RsaKeyObject {
+        &self.key.rsa_key_object
     }
 }
 
@@ -52,9 +64,8 @@ impl TryFrom<&PrivateKeyDer<'_>> for RsaPrivateKey {
                 let pkcs8: &[u8] = der.secret_pkcs8_der();
                 let pkcs8_sz: word32 = pkcs8.len() as word32;
                 let mut ret;
-                let rsa_key_box = Box::new(unsafe { mem::zeroed::<RsaKey>() });
-                let rsa_key_ptr = Box::into_raw(rsa_key_box);
-                let rsa_key_object = unsafe { RsaKeyObject::from_ptr(rsa_key_ptr) };
+                let mut rsa_key_box = Box::new(unsafe { mem::zeroed::<RsaKey>() });
+                let rsa_key_object = unsafe { RsaKeyObject::from_ptr(&mut *rsa_key_box) };
 
                 ret = unsafe { wc_InitRsaKey(rsa_key_object.as_ptr(), ptr::null_mut()) };
                 check_if_zero(ret).unwrap();
@@ -73,7 +84,10 @@ impl TryFrom<&PrivateKeyDer<'_>> for RsaPrivateKey {
                     .map_err(|_| rustls::Error::General("FFI function failed".into()))?;
 
                 Ok(Self {
-                    key: Arc::new(rsa_key_object),
+                    key: Arc::new(OwnedRsaKey {
+                        rsa_key_object,
+                        _rsa_key_box: rsa_key_box,
+                    }),
                     algo: SignatureAlgorithm::RSA,
                 })
             }
@@ -81,9 +95,8 @@ impl TryFrom<&PrivateKeyDer<'_>> for RsaPrivateKey {
                 let pkcs1: &[u8] = der.secret_pkcs1_der();
                 let pkcs1_sz: word32 = pkcs1.len() as word32;
                 let mut ret;
-                let rsa_key_box = Box::new(unsafe { mem::zeroed::<RsaKey>() });
-                let rsa_key_ptr = Box::into_raw(rsa_key_box);
-                let rsa_key_object = unsafe { RsaKeyObject::from_ptr(rsa_key_ptr) };
+                let mut rsa_key_box = Box::new(unsafe { mem::zeroed::<RsaKey>() });
+                let rsa_key_object = unsafe { RsaKeyObject::from_ptr(&mut *rsa_key_box) };
 
                 ret = unsafe { wc_InitRsaKey(rsa_key_object.as_ptr(), ptr::null_mut()) };
                 check_if_zero(ret).unwrap();
@@ -102,7 +115,10 @@ impl TryFrom<&PrivateKeyDer<'_>> for RsaPrivateKey {
                     .map_err(|_| rustls::Error::General("FFI function failed".into()))?;
 
                 Ok(Self {
-                    key: Arc::new(rsa_key_object),
+                    key: Arc::new(OwnedRsaKey {
+                        rsa_key_object,
+                        _rsa_key_box: rsa_key_box,
+                    }),
                     algo: SignatureAlgorithm::RSA,
                 })
             }
@@ -119,7 +135,7 @@ impl SigningKey for RsaPrivateKey {
         ALL_RSA_SCHEMES.iter().find_map(|&scheme| {
             if offered.contains(&scheme) {
                 Some(Box::new(RsaSigner {
-                    key: self.get_key(),
+                    key: Arc::clone(&self.key),
                     scheme,
                 }) as Box<dyn Signer>)
             } else {
@@ -135,24 +151,13 @@ impl SigningKey for RsaPrivateKey {
 
 #[derive(Clone, Debug)]
 pub struct RsaSigner {
-    key: Arc<RsaKeyObject>,
+    key: Arc<OwnedRsaKey>,
     scheme: SignatureScheme,
-}
-
-impl RsaSigner {
-    pub fn new(key: Arc<RsaKeyObject>, scheme: SignatureScheme) -> Self {
-        Self { key, scheme }
-    }
-
-    fn get_key(&self) -> Arc<RsaKeyObject> {
-        Arc::clone(&self.key)
-    }
 }
 
 impl Signer for RsaSigner {
     fn sign(&self, message: &[u8]) -> Result<Vec<u8>, rustls::Error> {
-        let rsa_key_arc = self.get_key();
-        let rsa_key_object = rsa_key_arc.as_ref();
+        let rsa_key_object = &self.key.rsa_key_object;
 
         // Prepare a random generator
         let mut rng: WC_RNG = unsafe { mem::zeroed() };

--- a/rustls-wolfcrypt-provider/src/types/mod.rs
+++ b/rustls-wolfcrypt-provider/src/types/mod.rs
@@ -69,6 +69,16 @@ macro_rules! define_foreign_type {
             }
         }
     };
+
+    ($struct_name:ident, $ref_name:ident, $c_type:ty, drop_void($drop_fn:ident), $init_function:ident) => {
+        define_foreign_type!($struct_name, $ref_name, $c_type, $init_function);
+
+        impl Drop for $struct_name {
+            fn drop(&mut self) {
+                unsafe { $drop_fn(self.as_ptr()) };
+            }
+        }
+    };
 }
 
 macro_rules! define_foreign_type_with_copy {
@@ -123,6 +133,64 @@ macro_rules! define_foreign_type_with_copy {
     };
 }
 
+/// Like define_foreign_type_with_copy but without Copy (needed when Drop is implemented).
+macro_rules! define_foreign_type_no_copy {
+    ($struct_name:ident, $ref_name:ident, $c_type:ty) => {
+        pub struct $ref_name(Opaque);
+        unsafe impl ForeignTypeRef for $ref_name {
+            type CType = $c_type;
+        }
+
+        #[derive(Debug, Clone)]
+        pub struct $struct_name(NonNull<$c_type>);
+        unsafe impl Sync for $struct_name {}
+        unsafe impl Send for $struct_name {}
+        unsafe impl ForeignType for $struct_name {
+            type CType = $c_type;
+            type Ref = $ref_name;
+
+            unsafe fn from_ptr(ptr: *mut Self::CType) -> Self {
+                Self(NonNull::new_unchecked(ptr))
+            }
+
+            fn as_ptr(&self) -> *mut Self::CType {
+                self.0.as_ptr()
+            }
+        }
+    };
+
+    ($struct_name:ident, $ref_name:ident, $c_type:ty, drop($drop_fn:ident)) => {
+        define_foreign_type_no_copy!($struct_name, $ref_name, $c_type);
+
+        impl Drop for $struct_name {
+            fn drop(&mut self) {
+                let ret = unsafe { $drop_fn(self.as_ptr()) };
+                match check_if_zero(ret) {
+                    Err(err) => {
+                        error!(
+                            "Error while freeing resource in Drop for {}: {}",
+                            stringify!($struct_name),
+                            err
+                        );
+                    }
+                    Ok(()) => {}
+                }
+            }
+        }
+    };
+
+    ($struct_name:ident, $ref_name:ident, $c_type:ty, drop_void($drop_fn:ident)) => {
+        define_foreign_type_no_copy!($struct_name, $ref_name, $c_type);
+
+        impl Drop for $struct_name {
+            fn drop(&mut self) {
+                unsafe { $drop_fn(self.as_ptr()) };
+            }
+        }
+    };
+
+}
+
 define_foreign_type!(
     WCRngObject,
     WCRngObjectRef,
@@ -134,17 +202,19 @@ define_foreign_type!(
     Curve25519KeyObject,
     Curve25519KeyObjectRef,
     curve25519_key,
+    drop_void(wc_curve25519_free),
     wc_curve25519_init
 );
-define_foreign_type!(ECCKeyObject, ECCKeyObjectRef, ecc_key, wc_ecc_init);
+define_foreign_type!(ECCKeyObject, ECCKeyObjectRef, ecc_key, drop(wc_ecc_free), wc_ecc_init);
 define_foreign_type!(
     ED25519KeyObject,
     ED25519KeyObjectRef,
     ed25519_key,
+    drop_void(wc_ed25519_free),
     wc_ed25519_init
 );
-define_foreign_type!(ED448KeyObject, ED448KeyObjectRef, ed448_key, wc_ed448_init);
+define_foreign_type!(ED448KeyObject, ED448KeyObjectRef, ed448_key, drop_void(wc_ed448_free), wc_ed448_init);
 
-define_foreign_type_with_copy!(RsaKeyObject, RsaKeyObjectRef, RsaKey);
+define_foreign_type_no_copy!(RsaKeyObject, RsaKeyObjectRef, RsaKey, drop(wc_FreeRsaKey));
 define_foreign_type_with_copy!(HmacObject, HmacObjectRef, wolfcrypt_rs::Hmac);
-define_foreign_type_with_copy!(AesObject, AesObjectRef, Aes);
+define_foreign_type_no_copy!(AesObject, AesObjectRef, Aes, drop_void(wc_AesFree));

--- a/rustls-wolfcrypt-provider/src/types/mod.rs
+++ b/rustls-wolfcrypt-provider/src/types/mod.rs
@@ -188,7 +188,6 @@ macro_rules! define_foreign_type_no_copy {
             }
         }
     };
-
 }
 
 define_foreign_type!(
@@ -205,7 +204,13 @@ define_foreign_type!(
     drop_void(wc_curve25519_free),
     wc_curve25519_init
 );
-define_foreign_type!(ECCKeyObject, ECCKeyObjectRef, ecc_key, drop(wc_ecc_free), wc_ecc_init);
+define_foreign_type!(
+    ECCKeyObject,
+    ECCKeyObjectRef,
+    ecc_key,
+    drop(wc_ecc_free),
+    wc_ecc_init
+);
 define_foreign_type!(
     ED25519KeyObject,
     ED25519KeyObjectRef,
@@ -213,7 +218,13 @@ define_foreign_type!(
     drop_void(wc_ed25519_free),
     wc_ed25519_init
 );
-define_foreign_type!(ED448KeyObject, ED448KeyObjectRef, ed448_key, drop_void(wc_ed448_free), wc_ed448_init);
+define_foreign_type!(
+    ED448KeyObject,
+    ED448KeyObjectRef,
+    ed448_key,
+    drop_void(wc_ed448_free),
+    wc_ed448_init
+);
 
 define_foreign_type_no_copy!(RsaKeyObject, RsaKeyObjectRef, RsaKey, drop(wc_FreeRsaKey));
 define_foreign_type_with_copy!(HmacObject, HmacObjectRef, wolfcrypt_rs::Hmac);

--- a/rustls-wolfcrypt-provider/src/verify.rs
+++ b/rustls-wolfcrypt-provider/src/verify.rs
@@ -17,6 +17,8 @@ pub static ALGORITHMS: WebPkiSupportedAlgorithms = WebPkiSupportedAlgorithms {
         ECDSA_P384_SHA384,
         ECDSA_P521_SHA512,
         ED25519,
+        RSA_PSS_SHA512,
+        RSA_PKCS1_SHA512,
     ],
     mapping: &[
         (SignatureScheme::RSA_PSS_SHA256, &[RSA_PSS_SHA256]),
@@ -29,6 +31,8 @@ pub static ALGORITHMS: WebPkiSupportedAlgorithms = WebPkiSupportedAlgorithms {
         (SignatureScheme::ECDSA_NISTP384_SHA384, &[ECDSA_P384_SHA384]),
         (SignatureScheme::ECDSA_NISTP521_SHA512, &[ECDSA_P521_SHA512]),
         (SignatureScheme::ED25519, &[ED25519]),
+        (SignatureScheme::RSA_PSS_SHA512, &[RSA_PSS_SHA512]),
+        (SignatureScheme::RSA_PKCS1_SHA512, &[RSA_PKCS1_SHA512]),
     ],
 };
 

--- a/rustls-wolfcrypt-provider/src/verify/ecdsa.rs
+++ b/rustls-wolfcrypt-provider/src/verify/ecdsa.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::{check_if_one, check_if_zero, WCError},
+    error::{check_if_zero},
     types::*,
 };
 use alloc::vec;
@@ -133,16 +133,8 @@ impl SignatureVerificationAlgorithm for EcdsaVerifier {
                 ecc_key_object.as_ptr(),
             );
 
-            // If stat != 1, signature is invalid
-            if stat != 1 {
-                panic!("ret = {}, stat = {}", ret, stat);
-            }
-
-            if let Err(WCError::Failure) = check_if_one(stat) {
-                Err(InvalidSignature)
-            } else {
-                Ok(())
-            }
+            check_if_zero(ret).map_err(|_| InvalidSignature)?;
+            if stat == 1 { Ok(()) } else { Err(InvalidSignature) }
         }
     }
 }

--- a/rustls-wolfcrypt-provider/src/verify/ecdsa.rs
+++ b/rustls-wolfcrypt-provider/src/verify/ecdsa.rs
@@ -1,7 +1,4 @@
-use crate::{
-    error::{check_if_zero},
-    types::*,
-};
+use crate::{error::check_if_zero, types::*};
 use alloc::vec;
 use core::mem;
 use core::ptr;
@@ -134,7 +131,11 @@ impl SignatureVerificationAlgorithm for EcdsaVerifier {
             );
 
             check_if_zero(ret).map_err(|_| InvalidSignature)?;
-            if stat == 1 { Ok(()) } else { Err(InvalidSignature) }
+            if stat == 1 {
+                Ok(())
+            } else {
+                Err(InvalidSignature)
+            }
         }
     }
 }

--- a/rustls-wolfcrypt-provider/src/verify/eddsa.rs
+++ b/rustls-wolfcrypt-provider/src/verify/eddsa.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::{check_if_one, check_if_zero, WCError},
+    error::{check_if_zero},
     types::*,
 };
 use core::mem;
@@ -51,11 +51,8 @@ impl SignatureVerificationAlgorithm for Ed25519 {
                 ed25519_key_object.as_ptr(),
             );
 
-            if let Err(WCError::Failure) = check_if_one(ret) {
-                Ok(())
-            } else {
-                Err(InvalidSignature)
-            }
+            check_if_zero(ret).map_err(|_| InvalidSignature)?;
+            if stat == 1 { Ok(()) } else { Err(InvalidSignature) }
         }
     }
 }

--- a/rustls-wolfcrypt-provider/src/verify/eddsa.rs
+++ b/rustls-wolfcrypt-provider/src/verify/eddsa.rs
@@ -1,7 +1,4 @@
-use crate::{
-    error::{check_if_zero},
-    types::*,
-};
+use crate::{error::check_if_zero, types::*};
 use core::mem;
 use foreign_types::ForeignType;
 use rustls::pki_types::{AlgorithmIdentifier, InvalidSignature, SignatureVerificationAlgorithm};
@@ -52,7 +49,11 @@ impl SignatureVerificationAlgorithm for Ed25519 {
             );
 
             check_if_zero(ret).map_err(|_| InvalidSignature)?;
-            if stat == 1 { Ok(()) } else { Err(InvalidSignature) }
+            if stat == 1 {
+                Ok(())
+            } else {
+                Err(InvalidSignature)
+            }
         }
     }
 }

--- a/rustls-wolfcrypt-provider/src/verify/rsapkcs1.rs
+++ b/rustls-wolfcrypt-provider/src/verify/rsapkcs1.rs
@@ -1,5 +1,4 @@
 use crate::error::check_if_zero;
-use crate::error::*;
 use crate::types::*;
 use alloc::vec::Vec;
 use core::ffi::c_void;
@@ -70,10 +69,9 @@ impl SignatureVerificationAlgorithm for RsaPkcs1Sha256Verify {
             )
         };
 
-        if let Err(WCError::Failure) = check_if_zero(ret) {
-            Err(InvalidSignature)
-        } else {
-            Ok(())
+        match check_if_zero(ret) {
+            Ok(()) => Ok(()),
+            Err(_) => Err(InvalidSignature),
         }
     }
 }
@@ -137,10 +135,9 @@ impl SignatureVerificationAlgorithm for RsaPkcs1Sha384Verify {
             )
         };
 
-        if let Err(WCError::Failure) = check_if_zero(ret) {
-            Err(InvalidSignature)
-        } else {
-            Ok(())
+        match check_if_zero(ret) {
+            Ok(()) => Ok(()),
+            Err(_) => Err(InvalidSignature),
         }
     }
 }
@@ -204,10 +201,9 @@ impl SignatureVerificationAlgorithm for RsaPkcs1Sha512Verify {
             )
         };
 
-        if let Err(WCError::Failure) = check_if_zero(ret) {
-            Err(InvalidSignature)
-        } else {
-            Ok(())
+        match check_if_zero(ret) {
+            Ok(()) => Ok(()),
+            Err(_) => Err(InvalidSignature),
         }
     }
 }

--- a/rustls-wolfcrypt-provider/src/verify/rsapss.rs
+++ b/rustls-wolfcrypt-provider/src/verify/rsapss.rs
@@ -86,10 +86,9 @@ impl SignatureVerificationAlgorithm for RsaPssSha256Verify {
             )
         };
 
-        if let Err(WCError::Failure) = check_if_greater_than_zero(ret) {
-            Err(InvalidSignature)
-        } else {
-            Ok(())
+        match check_if_greater_than_zero(ret) {
+            Ok(()) => Ok(()),
+            Err(_) => Err(InvalidSignature),
         }
     }
 }
@@ -170,10 +169,9 @@ impl SignatureVerificationAlgorithm for RsaPssSha384Verify {
             )
         };
 
-        if let Err(WCError::Failure) = check_if_greater_than_zero(ret) {
-            Err(InvalidSignature)
-        } else {
-            Ok(())
+        match check_if_greater_than_zero(ret) {
+            Ok(()) => Ok(()),
+            Err(_) => Err(InvalidSignature),
         }
     }
 }
@@ -254,10 +252,9 @@ impl SignatureVerificationAlgorithm for RsaPssSha512Verify {
             )
         };
 
-        if let Err(WCError::Failure) = check_if_greater_than_zero(ret) {
-            Err(InvalidSignature)
-        } else {
-            Ok(())
+        match check_if_greater_than_zero(ret) {
+            Ok(()) => Ok(()),
+            Err(_) => Err(InvalidSignature),
         }
     }
 }

--- a/wolfcrypt-rs/build.rs
+++ b/wolfcrypt-rs/build.rs
@@ -67,11 +67,7 @@ fn generate_bindings() -> Result<()> {
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
     bindings
         .write_to_file(out_path.join("bindings.rs"))
-        .map_err(|e| {
-            io::Error::other(
-                format!("Couldn't write bindings: {}", e),
-            )
-        })
+        .map_err(|e| io::Error::other(format!("Couldn't write bindings: {}", e)))
 }
 
 /// Coordinates the complete setup process for WolfSSL.
@@ -108,12 +104,10 @@ fn download_wolfssl() -> Result<()> {
         .output()?;
 
     if !output.status.success() {
-        return Err(io::Error::other(
-            format!(
-                "Failed to download: {}",
-                String::from_utf8_lossy(&output.stderr)
-            ),
-        ));
+        return Err(io::Error::other(format!(
+            "Failed to download: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )));
     }
     println!("Download completed successfully.");
     Ok(())
@@ -129,12 +123,10 @@ fn unzip_wolfssl() -> Result<()> {
     let output = Command::new("unzip").arg(WOLFSSL_ZIP).output()?;
 
     if !output.status.success() {
-        return Err(io::Error::other(
-            format!(
-                "Failed to unzip: {}",
-                String::from_utf8_lossy(&output.stderr)
-            ),
-        ));
+        return Err(io::Error::other(format!(
+            "Failed to unzip: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )));
     }
     println!("Unzipping completed successfully.");
     Ok(())
@@ -195,13 +187,11 @@ fn run_command(cmd: &str, args: &[&str]) -> Result<()> {
     let output = Command::new(cmd).args(args).output()?;
 
     if !output.status.success() {
-        return Err(io::Error::other(
-            format!(
-                "Failed to execute {}: {}",
-                cmd,
-                String::from_utf8_lossy(&output.stderr)
-            ),
-        ));
+        return Err(io::Error::other(format!(
+            "Failed to execute {}: {}",
+            cmd,
+            String::from_utf8_lossy(&output.stderr)
+        )));
     }
     println!("{} completed successfully.", cmd);
     Ok(())

--- a/wolfcrypt-rs/build.rs
+++ b/wolfcrypt-rs/build.rs
@@ -62,14 +62,13 @@ fn generate_bindings() -> Result<()> {
         .clang_arg(format!("-I{}/", wolfssl_include_dir.to_str().unwrap()))
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         .generate()
-        .map_err(|_| io::Error::new(io::ErrorKind::Other, "Failed to generate bindings"))?;
+        .map_err(|_| io::Error::other("Failed to generate bindings"))?;
 
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
     bindings
         .write_to_file(out_path.join("bindings.rs"))
         .map_err(|e| {
-            io::Error::new(
-                io::ErrorKind::Other,
+            io::Error::other(
                 format!("Couldn't write bindings: {}", e),
             )
         })
@@ -109,8 +108,7 @@ fn download_wolfssl() -> Result<()> {
         .output()?;
 
     if !output.status.success() {
-        return Err(io::Error::new(
-            io::ErrorKind::Other,
+        return Err(io::Error::other(
             format!(
                 "Failed to download: {}",
                 String::from_utf8_lossy(&output.stderr)
@@ -131,8 +129,7 @@ fn unzip_wolfssl() -> Result<()> {
     let output = Command::new("unzip").arg(WOLFSSL_ZIP).output()?;
 
     if !output.status.success() {
-        return Err(io::Error::new(
-            io::ErrorKind::Other,
+        return Err(io::Error::other(
             format!(
                 "Failed to unzip: {}",
                 String::from_utf8_lossy(&output.stderr)
@@ -198,8 +195,7 @@ fn run_command(cmd: &str, args: &[&str]) -> Result<()> {
     let output = Command::new(cmd).args(args).output()?;
 
     if !output.status.success() {
-        return Err(io::Error::new(
-            io::ErrorKind::Other,
+        return Err(io::Error::other(
             format!(
                 "Failed to execute {}: {}",
                 cmd,


### PR DESCRIPTION
f-904  - 3d50bbc check stat instead of only checking ret when verifying signatures (ed25519)
f-905  - 1a3db7b remove panic when signatures are invalid (verify/ecdsa.rs)
f-907  - ef80b36 copy_from_slice could panic when source and destination lengths differ, slice
  indexing to prevent that. also the second copy_from_slice could overwrite the first one.
f-908  - 1cd5139 add missing RSA_PSS_SHA512 and RSA_PKCS1_SHA512 to the all array, which are already
  supported.
f-917  - 5b2f5cb (aes256gcm) copy_from_slice could panic when source and destination lengths differ,
  slice indexing to prevent that. also the second copy_from_slice could overwrite the first one.
f-909 - 5c0eb94 minor error in including ed448 as signature scheme in eddsa.rs
 f-911 - 81d18aa match on any Err variant not just WCError when checking signatures in rsa-pkcs1 and
  rsa-pss
 f-918 - 3654c59 proper error mapping and return in sign/eddsa.rs instead of panic
 f-914 - e7d5059 minor typo of the digest size in hmac_final (changed from sha3_384 to sha384)
 f-906/915/916 - 9476a30 remove hmacobject dangling pointer, heap allocate hmac struct via box, so it outlives
   hmac_init so that it remains valid for the lifetime of the hmac operation
 f-910 - a91c8f1 check returned value of wc_HKDF_Expand with proper error propagation
 f-912 - 9dc39df added drop implementations for the missing foreign types to prevent potential
  resource leaking; custom deallocation method for rsa to reclaim the Box allocation; implemented Send and Sync to send the new rsa object safely between
  threads
 f-919 - d0f6ed0 use the appropriate copy function in the clone implementations of sha256 and sha384,
  instead of doing bit by bit copies.
  f-920 - b154c1f add lengths checks when deriving the secret in the p-* apis, to validate the peer
  public key length before slicing (skipping 0x04 first byte) and return Result instead of panicking.
  f-913 - 3d83b34 removing redundant check_if_zero, this was re-checking the wc_hmacfinal returned
  value
  f-921 - 254ec63 add zeroize crate to wipe key material from memory on drop (this applies for all the
  crypto modules)